### PR TITLE
個人的セッション設定機能の実装/セッション種別の送信機能の実装

### DIFF
--- a/packages/sodium/src/js/modules/Config.js
+++ b/packages/sodium/src/js/modules/Config.js
@@ -553,10 +553,12 @@ if (Config.isVMBrowser()) {
   });
 } else if (document.currentScript != null) {
   // content_scriptsによって書き込まれるオブジェクトのデシリアライズ
-  const session = new URLSearchParams(document.currentScript.dataset.session);
+  const session = Object.fromEntries(
+    new URLSearchParams(document.currentScript.dataset.session)
+  );
   Config.session = {
-    id: session.get("id"),
-    expires: Number(session.get("expires"))
+    ...session,
+    expires: Number(session.expires),
   };
 
   Config.settings = JSON.parse(document.currentScript.dataset.settings);

--- a/packages/videomark-log-view/src/Settings/PersonalSessionSettingItem.jsx
+++ b/packages/videomark-log-view/src/Settings/PersonalSessionSettingItem.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import PropTypes from "prop-types";
+import ListItem from "@material-ui/core/ListItem";
+import overwriteSessionId from "../js/utils/overwriteSessionId";
+import getSessionType from "../js/utils/getSessionType";
+
+/** 個人的セッションの設定用プロンプトの注入 - `ul` 要素用 */
+const PersonalSessionSettingItem = ({
+  children,
+  settings,
+  saveSettings,
+  saveSession,
+}) => {
+  const handleClick = React.useCallback(
+    (event) => {
+      if (!saveSession) return;
+      // NOTE: トリプルクリックすると個人的セッションの設定
+      if (event?.detail !== 3) return;
+      // TODO: prompt() は標準ではないので他の何らかのインタラクティブな入力方法に変更したい
+      const sessionId = prompt("セッションIDを入力してください").trim();
+      const type = getSessionType(sessionId);
+      if (type !== "personal") {
+        // TODO: alert() は標準ではないので他の何らかのインタラクティブな入力方法に変更したい
+        alert("他のセッションIDを入力してください");
+        return;
+      }
+      overwriteSessionId(settings, sessionId, {
+        saveSettings,
+        saveSession,
+      });
+    },
+    [settings, saveSettings, saveSession]
+  );
+
+  return (
+    // NOTE: フォーカスが当たらないように隠しておく
+    // eslint-disable-next-line jsx-a11y/interactive-supports-focus,jsx-a11y/click-events-have-key-events
+    <ListItem role="button" onClick={handleClick}>
+      {children}
+    </ListItem>
+  );
+};
+PersonalSessionSettingItem.propTypes = {
+  children: PropTypes.node,
+  settings: PropTypes.shape({ expires_in: PropTypes.number }),
+  saveSettings: PropTypes.instanceOf(Function),
+  saveSession: PropTypes.instanceOf(Function),
+};
+PersonalSessionSettingItem.defaultProps = {
+  children: null,
+  settings: undefined,
+  saveSettings: undefined,
+  saveSession: undefined,
+};
+export default PersonalSessionSettingItem;

--- a/packages/videomark-log-view/src/Settings/PrivacySettings.jsx
+++ b/packages/videomark-log-view/src/Settings/PrivacySettings.jsx
@@ -15,6 +15,7 @@ import formatDistanceStrict from "date-fns/formatDistanceStrict";
 import locale from "date-fns/locale/ja";
 import List from "./List";
 import Dialog from "./Dialog";
+import PersonalSessionSettingItem from "./PersonalSessionSettingItem";
 import {
   clearStore as clearStatsCache,
   getStoredIndex as getStatsCacheIndex,
@@ -48,10 +49,8 @@ const sessionExpiresInMarks = [
  */
 const sessionExpiresInToValue = (expiresIn) =>
   (
-    sessionExpiresInMarks.find((mark) => mark.expiresIn === expiresIn) ||
-    sessionExpiresInMarks.find(
-      (mark) => mark.expiresIn === defaultSessionExpiresIn
-    )
+    sessionExpiresInMarks.find((mark) => mark.expiresIn === expiresIn) ??
+    sessionExpiresInMarks[sessionExpiresInMarks.length - 1]
   ).value;
 
 const useStyle = makeStyles((theme) => ({
@@ -202,12 +201,16 @@ const PrivacySettings = ({ settings, saveSettings, session, saveSession }) => {
       <Paper>
         {dialog}
         <List>
-          <ListItem>
+          <PersonalSessionSettingItem
+            settings={settings}
+            saveSettings={saveSettings}
+            saveSession={saveSession}
+          >
             <ListItemText
               primary="セッションID"
               secondary={sessionId === undefined ? "未設定" : sessionId}
             />
-          </ListItem>
+          </PersonalSessionSettingItem>
           <Divider component="li" />
           <SessionExpiresIn
             expiresIn={expiresIn}

--- a/packages/videomark-log-view/src/Settings/index.jsx
+++ b/packages/videomark-log-view/src/Settings/index.jsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 import { useLocation } from "react-router";
 import Container from "@material-ui/core/Container";
 import Box from "@material-ui/core/Box";
-import addYears from "date-fns/addYears";
 import Header from "./Header";
 import DesignSettings from "./DesignSettings";
 import PrivacySettings from "./PrivacySettings";
@@ -11,6 +10,7 @@ import Reset from "./Reset";
 import ThemeProvider from "../js/components/ThemeProvider";
 import { clearStore as clearStatsCache } from "../js/containers/StatsDataProvider";
 import { useSession, useSettings } from "../js/utils/ChromeExtensionWrapper";
+import overwriteSessionId from "../js/utils/overwriteSessionId";
 
 const useOverwriteSessionId = ({
   settings,
@@ -31,21 +31,10 @@ const useOverwriteSessionId = ({
   )
     return;
 
-  // NOTE: サーバー側で "_" が使えない
-  if (/_/.test(sessionId)) {
-    console.error("Session ID is invalid");
-    return;
-  }
-
-  // TODO: https://github.com/webdino/sodium/issues/233
-  // NOTE: オーバーフロー無く十分に長い適当な期間
-  const expiresIn = addYears(0, 10).getTime();
-
-  saveSettings({
-    ...settings,
-    expires_in: expiresIn,
+  overwriteSessionId(settings, sessionId, {
+    saveSettings,
+    saveSession,
   });
-  saveSession({ id: sessionId, expires: Date.now() + expiresIn });
 };
 
 export default () => {

--- a/packages/videomark-log-view/src/js/utils/ChromeExtensionWrapper/index.js
+++ b/packages/videomark-log-view/src/js/utils/ChromeExtensionWrapper/index.js
@@ -1,6 +1,7 @@
 import { forEach } from "p-iteration";
 import { useState, useEffect, useCallback } from "react";
 import { isVMBrowser, isExtension, isWeb } from "../Utils";
+import getSessionType from "../getSessionType";
 import EmbeddedData from "./EmbeddedData";
 
 export const VERSION = new Date("2019-07-18T00:00:00Z").getTime();
@@ -56,7 +57,17 @@ const useStorage = (key) => {
 
   return [state, save];
 };
-export const useSession = () => useStorage("session");
+export const useSession = () => {
+  const [state, save] = useStorage("session");
+  const saveSession = useCallback(
+    (attributes) => {
+      const type = getSessionType(attributes?.id ?? "");
+      return save({ ...attributes, type });
+    },
+    [save]
+  );
+  return [state, saveSession];
+};
 export const useSettings = () => useStorage("settings");
 
 export const isCurrentVersion = async () => {

--- a/packages/videomark-log-view/src/js/utils/Utils.js
+++ b/packages/videomark-log-view/src/js/utils/Utils.js
@@ -12,12 +12,9 @@ export const urlToVideoPlatform = (url) => {
 };
 
 export const isDevelop = () => process.env.NODE_ENV === "development";
-export const isVMBrowser = () =>
-  window.sodium !== undefined && window.chrome.storage === undefined;
-export const isExtension = () =>
-  window.sodium === undefined && window.chrome.storage !== undefined;
-export const isWeb = () =>
-  window.sodium === undefined && window.chrome.storage === undefined;
+export const isVMBrowser = () => "sodium" in window;
+export const isExtension = () => !isVMBrowser() && "storage" in window.chrome;
+export const isWeb = () => !(isVMBrowser() || isExtension());
 
 export const sizeFormat = (bytes, exponent) => {
   const divider = 1024 ** exponent;
@@ -38,10 +35,12 @@ export const isMobile = () => {
   const [platformInfo, setPlatformInfo] = useState(false);
 
   useEffect(() => {
-    if (window.sodium !== undefined) {
+    if (isWeb()) return;
+
+    if (isVMBrowser()) {
       setPlatformInfo({ os: "android" });
     } else {
-      chrome.runtime.getPlatformInfo(info => setPlatformInfo(info))
+      chrome.runtime.getPlatformInfo((info) => setPlatformInfo(info));
     }
   });
 

--- a/packages/videomark-log-view/src/js/utils/getSessionType.js
+++ b/packages/videomark-log-view/src/js/utils/getSessionType.js
@@ -1,0 +1,14 @@
+import { validate, version } from "uuid";
+
+/**
+ * セッションIDをもとにセッション種別を判定する
+ * @param {string} id セッションID
+ * @return {"social" | "personal"} セッション種別 -  社会的セッション: "social", 個人的セッション: "personal"
+ */
+function getSessionType(id) {
+  if (!validate(id)) return "personal";
+
+  return version(id) === 4 ? "social" : "personal";
+}
+
+export default getSessionType;

--- a/packages/videomark-log-view/src/js/utils/overwriteSessionId.js
+++ b/packages/videomark-log-view/src/js/utils/overwriteSessionId.js
@@ -1,0 +1,34 @@
+import addYears from "date-fns/addYears";
+
+// NOTE: サーバー側で "_" が使えない
+const invalidCharacters = /[^A-Za-z.-]/u;
+
+/**
+ * セッションIDの上書き処理
+ * @param {{ expires_in: number}} settings 設定オブジェクト
+ * @param {string} sessionId セッションID
+ * @param {Function} handlers.saveSettings 設定保存処理
+ * @param {Function} handlers.saveSession セッション保存処理
+ */
+function overwriteSessionId(settings, sessionId, handlers) {
+  if (settings === undefined) return;
+  if (!sessionId) return;
+
+  if (invalidCharacters.test(sessionId)) {
+    // TODO: alert() は標準ではないので他の何らかのインタラクティブな入力方法に変更したい
+    alert("他のセッションIDを入力してください");
+    console.error("Session ID is invalid");
+    return;
+  }
+
+  // NOTE: オーバーフロー無く十分に長い適当な期間
+  const expiresIn = addYears(0, 10).getTime();
+
+  handlers.saveSettings({
+    ...settings,
+    expires_in: expiresIn,
+  });
+  handlers.saveSession({ id: sessionId, expires: Date.now() + expiresIn });
+}
+
+export default overwriteSessionId;

--- a/packages/videomark-log-view/src/js/utils/overwriteSessionId.js
+++ b/packages/videomark-log-view/src/js/utils/overwriteSessionId.js
@@ -1,7 +1,7 @@
 import addYears from "date-fns/addYears";
 
 // NOTE: サーバー側で "_" が使えない
-const invalidCharacters = /[^A-Za-z.-]/u;
+const invalidCharacters = /[^0-9A-Za-z.-]/u;
 
 /**
  * セッションIDの上書き処理


### PR DESCRIPTION
- dev serverで設定画面にアクセスできない問題の修正
- 個人的セッション設定機能の実装/セッション種別の送信機能の実装

確認したこと:
設定 > セッションIDの部分をトリプルクリック > セッションIDの設定後セッション種別が開発用サーバーに送信されること
