### PR TITLE
セッションのリセット処理が視聴時実施されない問題の修正

### DIFF
--- a/packages/sodium/src/js/modules/SessionData.js
+++ b/packages/sodium/src/js/modules/SessionData.js
@@ -108,11 +108,14 @@ export default class SessionData {
             ? expiresIn
             : Config.get_default_session_expires_in())
       };
-      window.postMessage({
-        type: "FROM_SODIUM_JS",
-        method: "set_session",
-        ...session
-      }, "*");
+      window.postMessage(
+        {
+          type: "FROM_SODIUM_JS",
+          method: "set_session",
+          session,
+        },
+        "*"
+      );
     }
 
     this.session = session;

--- a/packages/videomark-extension/content_script.js
+++ b/packages/videomark-extension/content_script.js
@@ -177,9 +177,8 @@ const message_listener = async event => {
 
   switch (event.data.method) {
     case "set_session": {
-      const { id, expires } = event.data;
-      if (id == null || expires == null) return;
-      await storage.set({ session: { id, expires } });
+      const { session } = event.data;
+      await storage.set({ session });
       break;
     }
     case "set_video": {


### PR DESCRIPTION

https://github.com/videomark/videomark/blob/d2970a0e42cc6dcd4d4ca37a9201f24daa268539/packages/sodium/src/js/modules/SessionData.js#L111-L115

ここでマージされており videomark/videomark#116 の変更に伴い追加した `type` プロパティが衝突することで上書きされた結果 `FROM_SODIUM_JS` が失われており、意図した振る舞いをしなくなっていたため修正します。

確認したこと: 初回視聴後、UUIDv4形式のセッションIDがデフォルトの期間で固定され設定画面に表示されること。また期限を0に設定すると次回視聴時に更新されること。