### PR TITLE
POST /api/latest_qoe への送信データ確認 #560

### DIFF
--- a/packages/sodium/src/js/modules/IIJTypeHandler.js
+++ b/packages/sodium/src/js/modules/IIJTypeHandler.js
@@ -109,6 +109,8 @@ export default class IIJTypeHandler extends GeneralTypeHandler {
 
     // eslint-disable-next-line camelcase
     static add_throughput_history(throughput) {
+        console.debug(`add_throughput_history: downloadSize=${throughput.downloadSize}`)
+        if (throughput.downloadSize <= 0) return;
         IIJTypeHandler.throughputHistories.push(throughput);
         IIJTypeHandler.throughputHistories = IIJTypeHandler.throughputHistories.slice(-Config.get_max_throughput_history_size());
     }

--- a/packages/sodium/src/js/modules/ParaviTypeHandler.js
+++ b/packages/sodium/src/js/modules/ParaviTypeHandler.js
@@ -155,6 +155,8 @@ export default class ParaviTypeHandler {
 
     // eslint-disable-next-line camelcase
     static add_throughput_history(throughput) {
+        console.debug(`add_throughput_history: downloadSize=${throughput.downloadSize}`)
+        if (throughput.downloadSize <= 0) return;
         ParaviTypeHandler.throughputHistories.push(throughput);
         ParaviTypeHandler.throughputHistories = ParaviTypeHandler.throughputHistories.slice(-Config.get_max_throughput_history_size());
     }

--- a/packages/sodium/src/js/modules/SessionData.js
+++ b/packages/sodium/src/js/modules/SessionData.js
@@ -387,6 +387,10 @@ export default class SessionData {
   }
 
   async requestQoE(video) {
+    console.debug(`VIDEOMARK: requestQoE [${this.session.id}][${video.get_video_id()}]`);
+    if (!this.session.id || !video.get_video_id()) {
+      throw new Error("SodiumServer(qoe) bad request.");
+    }
     const ret = await fetch(`${Config.get_sodium_server_url()}/latest_qoe`, {
       method: "POST",
       headers: {

--- a/packages/sodium/src/js/modules/YouTubeTypeHandler.js
+++ b/packages/sodium/src/js/modules/YouTubeTypeHandler.js
@@ -268,6 +268,8 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
     }
 
     static add_throughput_history(throughput) {
+        console.debug(`add_throughput_history: downloadSize=${throughput.downloadSize}`)
+        if (throughput.downloadSize <= 0) return;
         YouTubeTypeHandler.throughputHistories.push(throughput);
         YouTubeTypeHandler.throughputHistories = YouTubeTypeHandler.throughputHistories.slice(-Config.get_max_throughput_history_size());
     }


### PR DESCRIPTION
latest_qoe へ送信する前に session_id, video_id を確認する

動作確認では 124 行目の次に、一時的に下記を記載し、ブラウザの Developer tools で Console ログを見て行った。
  this.session.id = null;
