### PR TITLE
GitHub Actions actions/setup-node の cache に対応

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,8 @@ jobs:
       - id: node
         run: echo "::set-output name=version::$(cat .nvmrc)"
       - uses: actions/setup-node@v2
-        with: { node-version: "${{ steps.node.version }}" }
-      - id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
         with:
-          path: ${{ steps.yarn_cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: yarn-
+          node-version: "${{ steps.node.version }}"
+          cache: yarn
       - run: yarn
       - run: yarn build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,14 +10,9 @@ jobs:
       - id: node
         run: echo "::set-output name=version::$(cat .nvmrc)"
       - uses: actions/setup-node@v2
-        with: { node-version: "${{ steps.node.version }}" }
-      - id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
         with:
-          path: ${{ steps.yarn_cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: yarn-
+          node-version: "${{ steps.node.version }}"
+          cache: yarn
       - run: yarn
         env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true" }
       - name: Install Japanese fonts.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,14 +8,9 @@ jobs:
       - id: node
         run: echo "::set-output name=version::$(cat .nvmrc)"
       - uses: actions/setup-node@v2
-        with: { node-version: "${{ steps.node.version }}" }
-      - id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
         with:
-          path: ${{ steps.yarn_cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: yarn-
+          node-version: "${{ steps.node.version }}"
+          cache: yarn
       - run: yarn
       - run: yarn lint-report
         continue-on-error: true


### PR DESCRIPTION
[actions/setup-node](https://github.com/actions/setup-node#readmehttps://github.com/actions/setup-node#readme)でcacheを指定可能になったので対応し、いままでのactions/cacheの対応を削除します。
