### PR TITLE
計測データが貯まりすぎたらクライアント側で一部捨てるか送信を止める #562

### DIFF
--- a/packages/sodium/README.md
+++ b/packages/sodium/README.md
@@ -101,6 +101,16 @@ ChromeExtension/sodium.js
     // デフォルトResourceTiminingAPIのバッファサイズ
     Config.DEFAULT_RESOURCE_BUFFER_SIZE = 150;
 
+
+packages/sodium/webpack.dev.js
+packages/sodium/webpack.prod.js
+
+    // データの有効期間 (ミリ秒単位)
+    // 有効期間を過ぎたデータは送信対象外とする
+    DATA_VALIDITY_PERIOD: 180000,
+    QOE_VALIDITY_PERIOD: 180000,
+
+
 ステータス表示は、次のコードで div タグを作成し DOM に追加し値を表示しています。
 
         status_elm = document.createElement("div");

--- a/packages/sodium/src/js/modules/Config.js
+++ b/packages/sodium/src/js/modules/Config.js
@@ -133,6 +133,14 @@ export default class Config {
     return this.peak_time_limit_url;
   }
 
+  static get_data_validity_period() {
+    return this.data_validity_period;
+  }
+
+  static get_qoe_validity_period() {
+    return this.qoe_validity_period;
+  }
+
   static is_quality_control() {
     return this.quality_control;
   }
@@ -248,6 +256,11 @@ Config.sodium_server_url = SODIUM_SERVER_URL;
 
 // ネットワークの混雑する時間帯には自動的にビットレートを制限する設定ファイル
 Config.peak_time_limit_url = PEAK_TIME_LIMIT_URL;
+
+// データの有効期間 (ミリ秒単位)
+// 有効期間を過ぎたデータは送信対象外とする
+Config.data_validity_period = DATA_VALIDITY_PERIOD;
+Config.qoe_validity_period = QOE_VALIDITY_PERIOD;
 
 // 暫定QoE値保持数
 Config.num_of_latest_qoe = 20;

--- a/packages/sodium/src/js/modules/SessionData.js
+++ b/packages/sodium/src/js/modules/SessionData.js
@@ -338,6 +338,7 @@ export default class SessionData {
           try {
             // eslint-disable-next-line no-await-in-loop
             await this.sendData(mainVideo);
+            mainVideo.data_last_send = Date.now();
           } catch (e) {
             console.error(`VIDEOMARK: ${e}`);
           }
@@ -369,6 +370,7 @@ export default class SessionData {
           try {
             // eslint-disable-next-line no-await-in-loop
             qoe = await this.requestQoE(mainVideo);
+            mainVideo.qoe_last_send = Date.now();
           } catch (e) {
             console.error(`VIDEOMARK: ${e}`);
           }

--- a/packages/sodium/webpack.dev.js
+++ b/packages/sodium/webpack.dev.js
@@ -24,6 +24,10 @@ module.exports = merge(common, {
       PEAK_TIME_LIMIT_URL: JSON.stringify(
         "https://vm.webdino.org/peak-time-limit.json"
       ),
+
+      DATA_VALIDITY_PERIOD: 180000,
+      QOE_VALIDITY_PERIOD: 180000,
+
     }),
   ],
 

--- a/packages/sodium/webpack.prod.js
+++ b/packages/sodium/webpack.prod.js
@@ -15,6 +15,8 @@ module.exports = merge(common, {
       PEAK_TIME_LIMIT_URL: JSON.stringify(
         "https://vm.webdino.org/peak-time-limit.json"
       ),
+      DATA_VALIDITY_PERIOD: 180000,
+      QOE_VALIDITY_PERIOD: 180000,
     }),
   ],
 });


### PR DESCRIPTION
有効期限が過ぎたデータは送信対象外とする

下記ファイルで
 *  packages/sodium/webpack.dev.js
 *  packages/sodium/webpack.prod.js

下記プロパティを設定する（単位は msec とする）
 *  DATA_VALIDITY_PERIOD: 180000,（fluentd に対して）
 *  QOE_VALIDITY_PERIOD: 180000, （qoeに対して）

データの有効期限

* 未だ送信したことがない
現在 - play_start_time > validity_period
* 既に送信したことがある
現在 - 先に送信をした時間 > validity_period

動作確認として下記を行う。
* sodium リポジトリの develop ディレクトリの開発環境を起動する。
* ChromiumWebBrowser で youtube を視聴する。

下記のようなサーバーを停止して、有効期限が過ぎたものは packages/sodium/src/js/modules/VideoData.js の is_available() で false となることを確認する。（停止は一度に全部ではなく、個別に停止して試した。）
false になった後、停止したサーバーを起動すると、現在視聴しているものに対しては false 状態で、改めて別のものを視聴すると true となる。

* `docker stop develop_dev-sodium-nginx_1`
* fluentd に相当するものを停止 `docker stop develop_dev-sodium-fluent_1`
* SodiumServer を停止
* MockQoEServer を停止
