### PR TITLE
計測データが貯まりすぎたらクライアント側で一部捨てるか送信を止める #562

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -26,6 +26,7 @@ overrides:
       FLUENT_URL: readonly
       SODIUM_SERVER_URL: readonly
       PEAK_TIME_LIMIT_URL: readonly
+      EVENT_DATA_MAX_SIZE: readonly
   - files: "packages/videomark-extension/**"
     globals:
       sodium: readonly

--- a/packages/sodium/README.md
+++ b/packages/sodium/README.md
@@ -22,6 +22,8 @@ ChromeExtension/sodium.js
     Config.fluent_url = 'https://sodium.webdino.org/sodium';
     // SodiumServerのエンドポイント
     Config.sodium_server_url = 'https://sodium.webdino.org:8443/api';
+    // イベントデータのサイズの Max 値
+    Config.event_data_max_size = 81920; // 80kb =  1024 x 80
     // 暫定QoE値保持数
     Config.num_of_latest_qoe = 20; // 0に設定した場合すべての値を保存します。
     // 記録するイベントの種類のリスト

--- a/packages/sodium/README.md
+++ b/packages/sodium/README.md
@@ -23,7 +23,8 @@ ChromeExtension/sodium.js
     // SodiumServerのエンドポイント
     Config.sodium_server_url = 'https://sodium.webdino.org:8443/api';
     // イベントデータのサイズの Max 値
-    Config.event_data_max_size = 81920; // 80kb =  1024 x 80
+    // server's default request body size x 0.8 (1mb x 0.8 x 1024)
+    Config.event_data_max_size = 819200;
     // 暫定QoE値保持数
     Config.num_of_latest_qoe = 20; // 0に設定した場合すべての値を保存します。
     // 記録するイベントの種類のリスト

--- a/packages/sodium/src/js/modules/Config.js
+++ b/packages/sodium/src/js/modules/Config.js
@@ -133,6 +133,10 @@ export default class Config {
     return this.peak_time_limit_url;
   }
 
+  static get_event_data_max_size() {
+    return this.event_data_max_size;
+  }
+
   static is_quality_control() {
     return this.quality_control;
   }
@@ -248,6 +252,8 @@ Config.sodium_server_url = SODIUM_SERVER_URL;
 
 // ネットワークの混雑する時間帯には自動的にビットレートを制限する設定ファイル
 Config.peak_time_limit_url = PEAK_TIME_LIMIT_URL;
+
+Config.event_data_max_size = EVENT_DATA_MAX_SIZE;
 
 // 暫定QoE値保持数
 Config.num_of_latest_qoe = 20;

--- a/packages/sodium/src/js/modules/VideoData.js
+++ b/packages/sodium/src/js/modules/VideoData.js
@@ -375,11 +375,18 @@ export default class VideoData {
       val[`event_${s}`] = [];
       val[`event_${s}_delta`] = [];
     });
-    const list = this.events.splice(0, this.events.length);
-    list.forEach(e => {
-      val[`event_${e.type}`].push(e.get());
-      val[`event_${e.type}_delta`].push(e.get_delta());
-    });
+    const list = this.events.splice(0, this.events.length).reverse();
+    let data_sz = Config.get_event_data_max_size();
+    for (const e of list) {
+      data_sz -= JSON.stringify(e.get()).length;
+      data_sz -= JSON.stringify(e.get_delta()).length;
+      if (data_sz < 0) {
+        console.debug(`event_data_sz max=${Config.get_event_data_max_size()} over=${-data_sz}`);
+        break;
+      }
+      val[`event_${e.type}`].splice(0, 0, e.get());
+      val[`event_${e.type}_delta`].splice(0, 0, e.get_delta());
+    }
     return val;
   }
 

--- a/packages/sodium/webpack.dev.js
+++ b/packages/sodium/webpack.dev.js
@@ -24,6 +24,10 @@ module.exports = merge(common, {
       PEAK_TIME_LIMIT_URL: JSON.stringify(
         "https://vm.webdino.org/peak-time-limit.json"
       ),
+
+      // 80kb = 1024 x 80
+      EVENT_DATA_MAX_SIZE: 81920,
+
     }),
   ],
 

--- a/packages/sodium/webpack.dev.js
+++ b/packages/sodium/webpack.dev.js
@@ -25,8 +25,8 @@ module.exports = merge(common, {
         "https://vm.webdino.org/peak-time-limit.json"
       ),
 
-      // 80kb = 1024 x 80
-      EVENT_DATA_MAX_SIZE: 81920,
+      // server's default request body size x 0.8 (1mb x 0.8 x 1024)
+      EVENT_DATA_MAX_SIZE: 819200,
 
     }),
   ],

--- a/packages/sodium/webpack.prod.js
+++ b/packages/sodium/webpack.prod.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
       PEAK_TIME_LIMIT_URL: JSON.stringify(
         "https://vm.webdino.org/peak-time-limit.json"
       ),
-      EVENT_DATA_MAX_SIZE: 81920,
+      EVENT_DATA_MAX_SIZE: 819200,
     }),
   ],
 });

--- a/packages/sodium/webpack.prod.js
+++ b/packages/sodium/webpack.prod.js
@@ -15,6 +15,7 @@ module.exports = merge(common, {
       PEAK_TIME_LIMIT_URL: JSON.stringify(
         "https://vm.webdino.org/peak-time-limit.json"
       ),
+      EVENT_DATA_MAX_SIZE: 81920,
     }),
   ],
 });


### PR DESCRIPTION
EVENT_DATA_MAX_SIZE で設定した値を "event_..." のデータの size の max 値となるようにする。