### PR TITLE
fix: ポップアップが表示されない問題の修正

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,7 @@ extends:
   - "eslint:recommended"
   - "plugin:jsx-a11y/recommended"
   - "plugin:react/recommended"
+  - "plugin:react-hooks/recommended"
 env:
   webextensions: true
   browser: true
@@ -15,6 +16,8 @@ parserOptions:
 settings:
   react:
     version: detect
+rules:
+  react-hooks/rules-of-hooks: "off"
 overrides:
   - files: "packages/sodium/**"
     rules:
@@ -35,8 +38,20 @@ overrides:
     rules:
       jsx-a11y/no-autofocus: "off"
       react/display-name: "off"
+      react-hooks/rules-of-hooks: "error"
     globals:
       process: readonly
+  - files: # TODO: これらのファイルの warning は修正して取り除いて
+      - packages/videomark-log-view/src/Rollback.jsx
+      - packages/videomark-log-view/src/Settings/BitrateControlSettings.jsx
+      - packages/videomark-log-view/src/Settings/Reset.jsx
+      - packages/videomark-log-view/src/StatsSummary.jsx
+      - packages/videomark-log-view/src/js/containers/MiniStatsDownloadButton.jsx
+      - packages/videomark-log-view/src/js/containers/StatsDataProvider.jsx
+      - packages/videomark-log-view/src/js/containers/ViewingDetail.jsx
+      - packages/videomark-log-view/src/js/utils/ChromeExtensionWrapper/index.js
+    rules:
+      react-hooks/exhaustive-deps: "off"
   - files: "packages/videomark-mini-stats/**"
     rules:
       react/prop-types: "off"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint": "^7.7.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "lerna": "^3.22.1",
     "npm-run-all": "^4.1.5"
   },

--- a/packages/videomark-log-view/src/QualityUiSetting.jsx
+++ b/packages/videomark-log-view/src/QualityUiSetting.jsx
@@ -67,10 +67,6 @@ const List = styled(MuiList)({
 const QualityUiSetting = () => {
   const { alive, displayOnPlayer, setDisplayOnPlayer } = useTabStatus();
 
-  if (!alive) {
-    return null;
-  }
-
   const mobile = isMobile();
 
   const handleDisplaySettingChange = useCallback(
@@ -85,6 +81,8 @@ const QualityUiSetting = () => {
     },
     [displayOnPlayer, setDisplayOnPlayer]
   );
+
+  if (!alive) return null;
 
   return (
     <Box marginY={4}>

--- a/packages/videomark-log-view/src/QualityUiSetting.jsx
+++ b/packages/videomark-log-view/src/QualityUiSetting.jsx
@@ -7,7 +7,7 @@ import MuiList from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Switch from "@material-ui/core/Switch";
-import { isMobile } from "./js/utils/Utils.js";
+import { useMobile } from "./js/utils/Utils.js";
 
 const getRandomToken = () => {
   const randomPool = new Uint8Array(16);
@@ -67,7 +67,7 @@ const List = styled(MuiList)({
 const QualityUiSetting = () => {
   const { alive, displayOnPlayer, setDisplayOnPlayer } = useTabStatus();
 
-  const mobile = isMobile();
+  const mobile = useMobile();
 
   const handleDisplaySettingChange = useCallback(
     () => {

--- a/packages/videomark-log-view/src/Settings/BitrateControlSettings.jsx
+++ b/packages/videomark-log-view/src/Settings/BitrateControlSettings.jsx
@@ -11,7 +11,7 @@ import Switch from "@material-ui/core/Switch";
 import Slider from "@material-ui/core/Slider";
 import Link from "@material-ui/core/Link";
 import List from "./List";
-import { isMobile } from "../js/utils/Utils";
+import { useMobile } from "../js/utils/Utils";
 
 const useStyles = makeStyles((theme) => ({
   slider: {
@@ -351,7 +351,7 @@ const BitrateControlSettings = ({ settings, saveSettings }) => {
     );
   }
 
-  const mobile = isMobile();
+  const mobile = useMobile();
 
   return (
     <Box marginY={4}>

--- a/packages/videomark-log-view/src/Settings/DesignSettings.jsx
+++ b/packages/videomark-log-view/src/Settings/DesignSettings.jsx
@@ -8,7 +8,7 @@ import MuiList from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Switch from "@material-ui/core/Switch";
-import { isMobile } from "../js/utils/Utils";
+import { useMobile } from "../js/utils/Utils";
 
 const List = styled(MuiList)({
   padding: 0,
@@ -29,7 +29,7 @@ const DesignSettings = ({ settings, saveSettings }) => {
     },
     [changes, setChanges, settings, saveSettings]
   );
-  const mobile = isMobile();
+  const mobile = useMobile();
 
   return (
     <Box marginY={4}>

--- a/packages/videomark-log-view/src/js/utils/Utils.js
+++ b/packages/videomark-log-view/src/js/utils/Utils.js
@@ -31,7 +31,7 @@ export const megaSizeFormat = (bytes) => sizeFormat(bytes, 2);
 export const kiloSizeFormat = (bytes) => sizeFormat(bytes, 1);
 
 // 必ず変数に確保してから使うこと。条件式に直接使ってはいけない
-export const isMobile = () => {
+export const useMobile = () => {
   const [platformInfo, setPlatformInfo] = useState(false);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,7 +3038,6 @@
 
 "@videomark/sparkline@github:videomark/sparkline":
   version "0.3.10"
-  uid da263f1f1429787c606fe5885c9b85518472f4c2
   resolved "https://codeload.github.com/videomark/sparkline/tar.gz/da263f1f1429787c606fe5885c9b85518472f4c2"
 
 "@videomark/videomark-mini-stats@file:packages/videomark-mini-stats":
@@ -6471,6 +6470,11 @@ eslint-plugin-prettier@^3.1.4:
   integrity sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
 eslint-plugin-react@^7.20.6:
   version "7.21.5"


### PR DESCRIPTION
早期 return より後のフックの呼び出しは禁止されているため順序を修正します。

関連: b25310450b5d01354b28bdc0ad453d4efde5b365, PR #130 にて早期returnに修正したほうが良いと提案したのですが改めて調べたところ下記の規約に違反しているようです。確認不足ですみませんでした… :pray: > @kyoshino 

参考文献: https://ja.reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level

やったこと:

- fix: ポップアップが表示されない問題の修正
- フックAPIに依存しているならば接頭辞useを付けるリファクタリング
- フックAPIの規約を守る目的でeslint-plugin-react-hooksの導入

確認したこと:

開発用のビルドを作成後、インストールを実施し、動画視聴時に拡張機能ポップアップメニューにアクセス可能であること
