### PR TITLE
GitHub Actions の環境にてビットレートの検知の部分で失敗するためスキップ

### DIFF
--- a/test/e2e/index.test.js
+++ b/test/e2e/index.test.js
@@ -84,7 +84,8 @@ test.each(["youtube" /*, "paravi"*/])(
   90e3
 );
 
-test("YouTubeトップから動画ページに移動し、ビットレートを検知", async () => {
+// FIXME: GitHub Actions の環境にてビットレートの検知の部分で失敗するためスキップ
+test.skip("YouTubeトップから動画ページに移動し、ビットレートを検知", async () => {
   await page.goto("https://www.youtube.com/");
   await page.click(`a[href^="/watch?v="]`);
   const videomark = "#__videomark_ui";


### PR DESCRIPTION
毎回失敗しているが無視しており新しい問題が発生した際に見逃す可能性があるため、修正の目処が立てられるまで無効化