### PR TITLE
MessagePack への変換前に JSON.parse(JSON.stringify(payload)) する #684

### DIFF
--- a/packages/sodium/src/js/modules/SessionData.js
+++ b/packages/sodium/src/js/modules/SessionData.js
@@ -29,7 +29,7 @@ import { version } from "../../../package.json";
  * @param {Payload} payload
  */
 async function send(payload) {
-  const body = msgpack.encode(payload);
+  const body = msgpack.encode(JSON.parse(JSON.stringify(payload)));
   if (body.length > Config.get_max_send_size())
     console.warn(`VIDEOMARK: Too large payload packed body size is ${body.length}`);
 


### PR DESCRIPTION
件の通り。
https://github.com/webdino/sodium/issues/684