### PR TITLE
fix: Netlifyでビルド失敗する問題の回避

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: node
-        run: echo "::set-output name=version::$(cat .nvmrc)"
       - uses: actions/setup-node@v2
         with:
-          node-version: "${{ steps.node.version }}"
+          node-version-file: .nvmrc
           cache: yarn
       - run: yarn
       - run: yarn build
@@ -19,11 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo xcode-select -s "/Applications/Xcode_12.5.1.app/Contents/Developer"
-      - id: node
-        run: echo "::set-output name=version::$(cat .nvmrc)"
       - uses: actions/setup-node@v2
         with:
-          node-version: "${{ steps.node.version }}"
+          node-version-file: .nvmrc
           cache: yarn
       - run: yarn
       - run: yarn build-safari

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,11 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: node
-        run: echo "::set-output name=version::$(cat .nvmrc)"
       - uses: actions/setup-node@v2
         with:
-          node-version: "${{ steps.node.version }}"
+          node-version-file: .nvmrc
           cache: yarn
       - run: yarn
         env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true" }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: node
-        run: echo "::set-output name=version::$(cat .nvmrc)"
       - uses: actions/setup-node@v2
         with:
-          node-version: "${{ steps.node.version }}"
+          node-version-file: .nvmrc
           cache: yarn
       - run: yarn
       - run: yarn lint-report

--- a/bin/build
+++ b/bin/build
@@ -14,6 +14,9 @@ cd -- "$(dirname -- "$0")/.."
 log "Working directory is: $(pwd)"
 log "BUILD START: videomark-extension"
 
+# TODO: https://github.com/webdino/sodium/issues/741
+export NODE_OPTIONS=--openssl-legacy-provider
+
 yarn workspaces run build
 
 log cleanup

--- a/bin/build-android
+++ b/bin/build-android
@@ -14,6 +14,9 @@ cd -- "$(dirname -- "$0")/.."
 log "Working directory is: $(pwd)"
 log "BUILD START: videomark-browser"
 
+# TODO: https://github.com/webdino/sodium/issues/741
+export NODE_OPTIONS=--openssl-legacy-provider
+
 yarn workspace @videomark/sodium run build
 yarn workspace @videomark/videomark-log-view run build-android
 


### PR DESCRIPTION
古いバージョンのOpenSSLへの依存関係が存在するため `NODE_OPTIONS=--openssl-legacy-provider` を暫定的に指定して回避
