### PR TITLE
Abema Live 対応

### DIFF
--- a/packages/sodium/src/js/modules/AbemaTVLiveTypeHandler.js
+++ b/packages/sodium/src/js/modules/AbemaTVLiveTypeHandler.js
@@ -169,6 +169,12 @@ export default class AbemaTVLiveTypeHandler extends GeneralTypeHandler {
   }
 
   is_cm() {
+    const v = document.querySelector('video[style*="display: block"]');
+    if (!v) return true;
+    const k = Object.keys(REPRESENTATION_TABLE).find(
+      (e) => e === String(v.videoHeight)
+    );
+    if (!k) return true;
     return false;
   }
 

--- a/packages/sodium/src/js/modules/AbemaTVLiveTypeHandler.js
+++ b/packages/sodium/src/js/modules/AbemaTVLiveTypeHandler.js
@@ -1,36 +1,131 @@
 import GeneralTypeHandler from "./GeneralTypeHandler";
 
+const DURATION = 60 * 60 * 2; // 動画サイズは 2 時間の固定にする
+const RECEIVED_BUFFER_OFFSET = 5; // 5 秒分先読みを固定値で挿入
+const DEFAULT_REPRESENTATION_KEY = 480;
+const REPRESENTATION_TABLE = {
+  // MPD の内容を切り出した固定値
+  1080: {
+    bandwidth: 4000000,
+    codec: "avc1.640029",
+    framerate: 29.97, // 30000 / 1001,
+    height: 1080,
+    width: 1920,
+    bitrate: 4000000,
+  },
+  720: {
+    bandwidth: 2000000,
+    codec: "avc1.640029",
+    framerate: 29.97, // 30000 / 1001,
+    height: 720,
+    width: 1280,
+    bitrate: 2000000,
+  },
+  480: {
+    bandwidth: 900000,
+    codec: "avc1.640029",
+    framerate: 29.97, // 30000 / 1001,
+    height: 480,
+    width: 854,
+    bitrate: 900000,
+  },
+  240: {
+    bandwidth: 240000,
+    codec: "avc1.640029",
+    framerate: 29.97, // 30000 / 1001,
+    height: 240,
+    width: 426,
+    bitrate: 240000,
+  },
+  180: {
+    bandwidth: 120000,
+    codec: "avc1.640029",
+    framerate: 29.97, // 30000 / 1001,
+    height: 180,
+    width: 320,
+    bitrate: 120000,
+  },
+};
+
+let current;
+
+function equal_videos(a, b) {
+  if (a.length != b.length) return false;
+  return !Array.from(a).find((e, i) => e != b[i]);
+}
+
+function get_representation() {
+  const default_representation =
+    REPRESENTATION_TABLE[DEFAULT_REPRESENTATION_KEY];
+  const v = document.querySelector('video[style*="display: block"]');
+  if (!v) return default_representation;
+  const k = Object.keys(REPRESENTATION_TABLE).find(
+    (e) => e === String(v.videoHeight)
+  );
+  if (!k) return default_representation;
+  return REPRESENTATION_TABLE[k];
+}
+
 /* あまり有用な情報は取り出せない */
 export default class AbemaTVLiveTypeHandler extends GeneralTypeHandler {
-  constructor(elm) {
-    super(elm);
+  constructor() {
+    super(null);
 
-    if (!this.is_main_video(elm)) throw new Error("video is not main");
+    if (current && equal_videos(current, document.querySelectorAll("video")))
+      throw new Error("ignore this video");
 
-    this.elm = elm;
+    current = document.querySelectorAll("video");
+    this.start_time = Date.now();
   }
 
   // eslint-disable-next-line class-methods-use-this
   get_duration() {
     /* video.duration には、1FFFFFFFFFFFFF が入っているため使用できない */
-    return -1;
+    /* 上記の理由により固定値 DURATION を使用 */
+    return DURATION;
+  }
+
+  /* CM 時の resolution を判定可能にするため width, height は表示中の video から取得する */
+  /* ただし、CM 時の video の resolution が REPRESENTATION_TABLE に含まれている場合判断することはできない */
+  get_video_width() {
+    return document.querySelector('video[style*="display: block"]').videoWidth;
+  }
+
+  /* CM 時の resolution を判定可能にするため width, height は表示中の video から取得する */
+  /* ただし、CM 時の video の resolution が REPRESENTATION_TABLE に含まれている場合判断することはできない */
+  get_video_height() {
+    return document.querySelector('video[style*="display: block"]').videoHeight;
+  }
+
+  /* 表示中の video の height が REPRESENTATION_TABLE にない場合 DEFAULT_REPRESENTATION_KEY の値を返す */
+  get_bitrate() {
+    const { bitrate } = get_representation();
+    return bitrate;
+  }
+
+  get_video_bitrate() {
+    return this.get_bitrate();
   }
 
   // eslint-disable-next-line class-methods-use-this
   get_receive_buffer() {
-    /* buffered には、現在時刻が入っているため使用できない */
-    return -1;
+    // RECEIVED_BUFFER_OFFSET 秒分先読みを固定値で挿入
+    return this.get_current_time() + RECEIVED_BUFFER_OFFSET;
+  }
+
+  /* 表示中の video の height が REPRESENTATION_TABLE にない場合 DEFAULT_REPRESENTATION_KEY の値を返す */
+  get_framerate() {
+    const { framerate } = get_representation();
+    return framerate;
   }
 
   // eslint-disable-next-line class-methods-use-this
   get_segment_domain() {
-    return document.domain;
+    return "ds-linear-abematv.akamaized.net";
   }
 
-  // eslint-disable-next-line no-unused-vars, class-methods-use-this
-  get_current_time(video) {
-    /* currentTime には、現在時刻が入っているため使用できない */
-    return -1;
+  get_current_time() {
+    return ((Date.now() - this.start_time) / 1000) % DURATION;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -44,8 +139,9 @@ export default class AbemaTVLiveTypeHandler extends GeneralTypeHandler {
 
   // eslint-disable-next-line class-methods-use-this
   get_video_thumbnail() {
-    /* あとから見ることができるような、固定されたサムネイルはなさそう */
-    return "";
+    return `https://hayabusa.io/abema/channels/logo/${
+      location.pathname.split("/").slice(-1)[0]
+    }?format=png&height=48&quality=30&version=20200413&width=128&background=black`;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -54,33 +150,25 @@ export default class AbemaTVLiveTypeHandler extends GeneralTypeHandler {
     return "";
   }
 
-  /**
-   * 複数のCMは、<video> を使い捨てして再生している
-   * 判定するの難しい <video> だけで判断はできないかも
-   *
-   * CMを判断するのが難しいためすべてメインとして送信する。
-   * ただし、session:video = 1:1の関係があるため、
-   * is_main_videoでは、現在表示中の <video> を一つ選んでいる。
-   */
-  // eslint-disable-next-line class-methods-use-this
-  is_main_video(video) {
-    try {
-      return window.getComputedStyle(video).display === "block";
-    } catch (e) {
-      return false;
-    }
+  get_total_frames() {
+    return Array.from(document.querySelectorAll("video")).reduce((acc, cur) => {
+      acc += cur.getVideoPlaybackQuality().totalVideoFrames;
+      return acc;
+    }, 0);
   }
 
-  /**
-   * 複数のCMは、<video> を使い捨てして再生している
-   * 判定するの難しい <video> だけで判断はできないかも
-   *
-   * CMを判断するのが難しいためすべてメインとして送信する。
-   * ただし、session:video = 1:1の関係があるため、
-   * is_main_videoでは、現在表示中の <video> を一つ選んでいる。
-   */
-  // eslint-disable-next-line no-unused-vars, class-methods-use-this
-  is_cm(video) {
+  get_dropped_frames() {
+    return Array.from(document.querySelectorAll("video")).reduce((acc, cur) => {
+      acc += cur.getVideoPlaybackQuality().droppedVideoFrames;
+      return acc;
+    }, 0);
+  }
+
+  is_main_video() {
+    return true;
+  }
+
+  is_cm() {
     return false;
   }
 

--- a/packages/sodium/src/js/modules/VideoData.js
+++ b/packages/sodium/src/js/modules/VideoData.js
@@ -72,6 +72,34 @@ export default class VideoData {
           func: l,
         });
       });
+    } else {
+      document.querySelectorAll("video").forEach((e) => {
+        Config.get_event_type_names().forEach((s) => {
+          if (s === "ended") {
+            e.addEventListener(s, (event) => {
+              console.log(
+                `VIDEOMARK: EVENT(D):${event.type}, ${Array.from(
+                  document.querySelectorAll("video")
+                ).indexOf(event.target)}, ID:${this.uuid}[${
+                  this.id_by_video_holder ? this.id_by_video_holder : this.uuid
+                }]`
+              );
+            });
+          } else {
+            this.last_events[s] = 0;
+
+            // eslint-disable-next-line no-underscore-dangle
+            const l = (event) => this._listener(event);
+
+            e.addEventListener(s, l);
+
+            this.listeners.push({
+              key: s,
+              func: l,
+            });
+          }
+        });
+      });
     }
 
     // eslint-disable-next-line no-underscore-dangle
@@ -457,17 +485,21 @@ export default class VideoData {
       this._is_cm()
     ) {
       console.log(
-        `VIDEOMARK: EVENT(D):${event.type}, VALUE:[${e.toJSON()}], ID:${
-          this.uuid
-        }[${this.id_by_video_holder ? this.id_by_video_holder : this.uuid}]`
+        `VIDEOMARK: EVENT(D):${event.type}, ${Array.from(
+          document.querySelectorAll("video")
+        ).indexOf(event.target)}, VALUE:[${e.toJSON()}], ID:${this.uuid}[${
+          this.id_by_video_holder ? this.id_by_video_holder : this.uuid
+        }]`
       );
       return;
     }
 
     console.log(
-      `VIDEOMARK: EVENT(A):${event.type}, VALUE:[${e.toJSON()}], ID:${
-        this.uuid
-      }[${this.id_by_video_holder ? this.id_by_video_holder : this.uuid}]`
+      `VIDEOMARK: EVENT(A):${event.type}, ${Array.from(
+        document.querySelectorAll("video")
+      ).indexOf(event.target)}, VALUE:[${e.toJSON()}], ID:${this.uuid}[${
+        this.id_by_video_holder ? this.id_by_video_holder : this.uuid
+      }]`
     );
 
     this.last_events[event.type] = e.time;

--- a/packages/sodium/src/js/modules/VideoData.js
+++ b/packages/sodium/src/js/modules/VideoData.js
@@ -57,19 +57,22 @@ export default class VideoData {
       resolution: -1,
     };
     // --- set event listener --- //
-    Config.get_event_type_names().forEach((s) => {
-      this.last_events[s] = 0;
+    // Abema Live は event を無視する
+    if (this.video_handler.service != "abematv_live") {
+      Config.get_event_type_names().forEach((s) => {
+        this.last_events[s] = 0;
 
-      // eslint-disable-next-line no-underscore-dangle
-      const l = (event) => this._listener(event);
+        // eslint-disable-next-line no-underscore-dangle
+        const l = (event) => this._listener(event);
 
-      this.video_elm.addEventListener(s, l);
+        this.video_elm.addEventListener(s, l);
 
-      this.listeners.push({
-        key: s,
-        func: l,
+        this.listeners.push({
+          key: s,
+          func: l,
+        });
       });
-    });
+    }
 
     // eslint-disable-next-line no-underscore-dangle
     const l = (event) => this._position_update_listener(event);
@@ -305,11 +308,11 @@ export default class VideoData {
   }
 
   totalFrames() {
-    return this.video_elm.getVideoPlaybackQuality().totalVideoFrames;
+    return this.video_handler.get_total_frames(this.video_elm);
   }
 
   droppedFrames() {
-    return this.video_elm.getVideoPlaybackQuality().droppedVideoFrames;
+    return this.video_handler.get_dropped_frames(this.video_elm);
   }
 
   /**

--- a/packages/sodium/src/js/modules/VideoHandler.js
+++ b/packages/sodium/src/js/modules/VideoHandler.js
@@ -61,6 +61,7 @@ export default class VideoHandler {
       } else if (url.pathname.split("/").indexOf("now-on-air") >= 0) {
         this.handler = new AbemaTVLiveTypeHandler(elm);
         this.service = "abematv_live";
+        this.calQoeFlg = true;
         console.log("Abema TV Live Type Handler");
       } else {
         throw new Error("AbemaTV ignores top page and unknown page video.");
@@ -233,6 +234,18 @@ export default class VideoHandler {
 
   get_service() {
     return this.service;
+  }
+
+  get_total_frames(video) {
+    if (this.handler instanceof AbemaTVLiveTypeHandler)
+      return this.handler.get_total_frames();
+    else return video.getVideoPlaybackQuality().totalVideoFrames;
+  }
+
+  get_dropped_frames(video) {
+    if (this.handler instanceof AbemaTVLiveTypeHandler)
+      return this.handler.get_dropped_frames();
+    else return video.getVideoPlaybackQuality().droppedVideoFrames;
   }
 
   is_main_video(video) {


### PR DESCRIPTION
注意点
- media size は 2 時間の固定値
- 読み込み済みバッファは再生時間 + 5 秒の固定値
- framerate, bitrate は MPD を解析した値をテーブルで持っている
- position は切り替えたタイミングからの経過時間
- イベントは無視する
- segment domain は `ds-linear-abematv.akamaized.net` の固定値
- resolution は再生中の video の videoHeight, videoWidth から取得している
- CM 時にテーブルに含まれていない resolution が再生された場合 デフォルト の 高さ 480 の framerate, bitrate が使用される
- CM 時の resolution が テーブルに含まれている値なら テーブルのものを使用する