### PR TITLE
onHeadersReceived の opt_extraInfoSpec に extraHeaders を追加

### DIFF
--- a/packages/videomark-extension/background.js
+++ b/packages/videomark-extension/background.js
@@ -40,7 +40,7 @@ chrome.webRequest.onHeadersReceived.addListener(
   {
     urls: ["<all_urls>"]
   },
-  ["blocking", "responseHeaders"]
+  ["blocking", "responseHeaders", "extraHeaders"]
 );
 
 chrome.webRequest.onResponseStarted.addListener(


### PR DESCRIPTION
chrome 79 以降 CORS 関連の ヘッダーの変更を行う場合、opt_extraInfoSpec に extraHeaders を指定する必要があるそうです。このオプションを追加したところ transferSize が取れるようになりました。
https://developer.chrome.com/docs/extensions/reference/webRequest/#manifest

以下のスクリーンショットは MockQoEServer を使用したものです。
![スクリーンショット 2022-12-07 135403](https://user-images.githubusercontent.com/34021806/206092983-f9b99582-a9bd-445b-80c8-c909f36f5bcb.png)
