### PR TITLE
VideoMark サイト URL を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Web VideoMark Project
 
-Web VideoMark プロジェクトの紹介、ツールのダウンロード、使用法などの説明は [Web VideoMark の Web サイト](https://vm.webdino.org/) をご覧ください。
+Web VideoMark プロジェクトの紹介、ツールのダウンロード、使用法などの説明は [Web VideoMark の Web サイト](https://videomark.webdino.org/) をご覧ください。
 
 ## Develop Environment
 

--- a/packages/sodium/webpack.dev.js
+++ b/packages/sodium/webpack.dev.js
@@ -22,7 +22,7 @@ module.exports = merge(common, {
       ),
 
       PEAK_TIME_LIMIT_URL: JSON.stringify(
-        "https://vm.webdino.org/peak-time-limit.json"
+        "https://videomark.webdino.org/peak-time-limit.json"
       ),
 
       // server's default request body size x 0.8 (1mb x 0.8 x 1024)

--- a/packages/sodium/webpack.prod.js
+++ b/packages/sodium/webpack.prod.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
       FLUENT_URL: JSON.stringify("https://sodium.webdino.org/sodium"),
       SODIUM_SERVER_URL: JSON.stringify("https://sodium.webdino.org:8443/api"),
       PEAK_TIME_LIMIT_URL: JSON.stringify(
-        "https://vm.webdino.org/peak-time-limit.json"
+        "https://videomark.webdino.org/peak-time-limit.json"
       ),
       EVENT_DATA_MAX_SIZE: 819200,
     }),

--- a/packages/videomark-extension/background.js
+++ b/packages/videomark-extension/background.js
@@ -68,7 +68,7 @@ chrome.runtime.onInstalled.addListener(({ reason, previousVersion }) => {
         version == null ? 0 : Number(version.slice(".")[0]);
       const majorVersion = major(chrome.runtime.getManifest().version);
       if (major(previousVersion) < majorVersion) {
-        const url = `https://vm.webdino.org/whatsnew/extension/${majorVersion}`;
+        const url = `https://videomark.webdino.org/whatsnew/extension/${majorVersion}`;
         chrome.tabs.create({ url });
       }
       break;

--- a/packages/videomark-extension/manifest.json
+++ b/packages/videomark-extension/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.12.0",
   "description": "Web VideoMark 拡張機能 - 動画配信サービス視聴時の品質情報を計測します。",
   "author": "WebDINO Japan",
-  "homepage_url": "http://vm.webdino.org/",
+  "homepage_url": "http://videomark.webdino.org/",
   "options_page": "qoelog/index.html#/settings",
   "applications": {
     "gecko": {

--- a/packages/videomark-extension/terms.html
+++ b/packages/videomark-extension/terms.html
@@ -127,12 +127,12 @@
             <div class="text">
               <p>
                 本ソフトウェアは日本国内を対象としており、日本国外でのご利用に対して一切のサポート・保証を行っておりません。また、本ソフトウェアのご利用には、<a
-                  href="https://vm.webdino.org/terms/"
+                  href="https://videomark.webdino.org/terms/"
                   target="_blank"
                   >利用規約</a
                 >
                 と
-                <a href="https://vm.webdino.org/privacy/" target="_blank"
+                <a href="https://videomark.webdino.org/privacy/" target="_blank"
                   >プライバシーポリシー</a
                 >に同意いただく必要があります。
               </p>
@@ -147,7 +147,7 @@
               <p>
                 本ソフトウェアは、体感品質 (QoE)
                 値の計算に動画再生時のビットレートやフレームレートもしくは利用者によるシーク操作といった、視聴情報を必要とします。取得される視聴情報は、<a
-                  href="https://vm.webdino.org/terms/"
+                  href="https://videomark.webdino.org/terms/"
                   target="_blank"
                   >利用規約</a
                 >

--- a/packages/videomark-log-view/public/unsupported.html
+++ b/packages/videomark-log-view/public/unsupported.html
@@ -11,7 +11,7 @@
     <section id="not-found">
       <div id="title">
         Please access with
-        <a href="http://vm.webdino.org/">Web VideoMark</a><br />
+        <a href="http://videomark.webdino.org/">Web VideoMark</a><br />
       </div>
       <div class="circles">
         <p>

--- a/packages/videomark-log-view/src/Settings/BitrateControlSettings.jsx
+++ b/packages/videomark-log-view/src/Settings/BitrateControlSettings.jsx
@@ -367,7 +367,7 @@ const BitrateControlSettings = ({ settings, saveSettings }) => {
               : null,
             "設定変更後の動画再生開始時の制限値に応じてビットレート選択が行われます。",
           ].join("")}
-          <Link href="https://vm.webdino.org/spec" color="secondary">
+          <Link href="https://videomark.webdino.org/spec" color="secondary">
             ビットレート制限に対応しているサイト
           </Link>
           をご確認下さい。

--- a/packages/videomark-log-view/src/js/utils/helpURL.js
+++ b/packages/videomark-log-view/src/js/utils/helpURL.js
@@ -4,6 +4,6 @@ const helpURL = ((base) => {
   if (isVMBrowser()) return new URL("android", base);
   if (isExtension()) return new URL("extension", base);
   return base;
-})(new URL("https://vm.webdino.org/help/"));
+})(new URL("https://videomark.webdino.org/help/"));
 
 export default helpURL;

--- a/packages/videomark-mini-stats/index.js
+++ b/packages/videomark-mini-stats/index.js
@@ -7,7 +7,7 @@ import JPText from "./components/JPText";
 import timeFormat from "./components/jpTimeFormat";
 import { playingTimeStats } from "./components/stats";
 const title = "VideoMark 動画視聴統計";
-const site = "https://vm.webdino.org";
+const site = "https://videomark.webdino.org";
 const width = 512; // px
 const height = 512; // px
 const appName = "videomark";

--- a/packages/videomark-mini-stats/index.tsx
+++ b/packages/videomark-mini-stats/index.tsx
@@ -20,7 +20,7 @@ interface Navigator {
 declare var navigator: Navigator;
 
 const title = "VideoMark 動画視聴統計";
-const site = "https://vm.webdino.org";
+const site = "https://videomark.webdino.org";
 const width = 512; // px
 const height = 512; // px
 const appName = "videomark";


### PR DESCRIPTION
`vm.webdino.org` から `videomark.webdino.org` に一括置換しました。