### PR TITLE
NODE_OPTIONS=--openssl-legacy-provider を取り除く

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -14,9 +14,6 @@ cd -- "$(dirname -- "$0")/.."
 log "Working directory is: $(pwd)"
 log "BUILD START: videomark-extension"
 
-# TODO: https://github.com/webdino/sodium/issues/741
-export NODE_OPTIONS=--openssl-legacy-provider
-
 pnpm --filter @videomark/* build
 
 log cleanup

--- a/bin/build-android
+++ b/bin/build-android
@@ -14,9 +14,6 @@ cd -- "$(dirname -- "$0")/.."
 log "Working directory is: $(pwd)"
 log "BUILD START: videomark-browser"
 
-# TODO: https://github.com/webdino/sodium/issues/741
-export NODE_OPTIONS=--openssl-legacy-provider
-
 pnpm --filter @videomark/sodium build
 pnpm --filter @videomark/videomark-log-view build-android
 


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/741

現状 Netlify へデプロイされていない & Svelte ベースの拡張機能 v2 への移行により、このオプションはもう必要なさそうです。