### PR TITLE
fix: Firefox 向け後方互換

### DIFF
--- a/public/manifest-firefox.json
+++ b/public/manifest-firefox.json
@@ -26,6 +26,7 @@
   "permissions": [
     "tabs",
     "webRequest",
+    "webRequestBlocking",
     "storage",
     "unlimitedStorage",
     "declarativeNetRequestWithHostAccess"


### PR DESCRIPTION
`webRequestBlocking` パーミッションは Manifest v3 では使用不可。 `declarativeNetRequest` が実装されていない Firefox 向け後方互換。

see https://bugzilla.mozilla.org/1687755

Co-authored-by: Kohei Yoshino <kohei.yoshino@gmail.com>

https://github.com/videomark/videomark/pull/205
