### PR TITLE
長時間の視聴を分割して計測

### DIFF
--- a/src/lib/content/sodium/README.md
+++ b/src/lib/content/sodium/README.md
@@ -16,6 +16,8 @@ ChromeExtension/sodium.js
     Config.trans_interval = 5 * 1000;
     // videoタグ検索インターバル(ミリ秒単位)
     Config.search_video_interval = 1 * 1000;
+    // videoの有効な最大時間(ミリ秒単位) この時間を超えると別の動画として新しく計測します
+    Config.max_video_ttl = 60 * 60 * 1000;
     // 暫定QoE値取得(回数)　Config.trans_interval x この値 が暫定QoE値取得インターバルになる
     Config.latest_qoe_update = 5;
     // fluentd サーバーのエンドポイント

--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -280,6 +280,9 @@ Config.collect_interval = 1 * 1000;
 // videoタグ検索インターバル(ミリ秒単位)
 Config.search_video_interval = 1 * 1000;
 
+// videoの有効な最大時間(ミリ秒単位)
+Config.max_video_ttl = 60 * 60 * 1000;
+
 // fluentd サーバーのエンドポイント
 Config.fluent_url = import.meta.env.SODIUM_FLUENT_URL;
 


### PR DESCRIPTION
resolved https://github.com/webdino/sodium/issues/885

1時間 (デフォルト) 以上の連続視聴を分割して QoE 推計を適切にします。
