### PR TITLE
fix: セッション保持期限に関わらず新しいセッションIDに変わる問題の修正

### DIFF
--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -615,18 +615,24 @@ if (Config.isVMBrowser()) {
   window.sodium.storage.local.get('peak_time_limit', ({ peak_time_limit }) => {
     Config.peak_time_limit = peak_time_limit || {};
   });
-} else if (document.currentScript !== null) {
+}
+
+const currentScript = Config.isVMBrowser()
+  ? null
+  : document.querySelector(`script[type="module"][src="${import.meta.url}"]`);
+
+if (currentScript !== null) {
   // content_scriptsによって書き込まれるオブジェクトのデシリアライズ
-  const session = Object.fromEntries(new URLSearchParams(document.currentScript.dataset.session));
+  const session = Object.fromEntries(new URLSearchParams(currentScript.dataset.session));
 
   Config.session = {
     ...session,
     expires: Number(session.expires),
   };
 
-  Config.settings = JSON.parse(document.currentScript.dataset.settings);
-  Config.transfer_size = JSON.parse(document.currentScript.dataset.transfer_size);
-  Config.peak_time_limit = JSON.parse(document.currentScript.dataset.peak_time_limit);
+  Config.settings = JSON.parse(currentScript.dataset.settings);
+  Config.transfer_size = JSON.parse(currentScript.dataset.transfer_size);
+  Config.peak_time_limit = JSON.parse(currentScript.dataset.peak_time_limit);
 }
 
 // デフォルトのセッション保持期間

--- a/src/lib/pages/routes/settings.svelte
+++ b/src/lib/pages/routes/settings.svelte
@@ -120,6 +120,7 @@
   });
 
   $: $session.type = getSessionType($session.id);
+  $: $session.expires = Date.now() + $settings.expires_in;
 </script>
 
 <HistoryLayout>


### PR DESCRIPTION
セッション保持期限の設定に関わらず、毎回新しいセッションIDに変わる不具合がありました。
セッション保持期限を反映されるようにします。

- document.currentScript プロパティは ES Module に存在しないため、代わりに対応 import.meta.url を使用するように変更します。
- セッション保持期限の設定を行ったとき session オブジェクトへの反映が行われていなかったので正しく反映されるように処理を追加しました。
