### PR TITLE
レスポンシブ対応

### DIFF
--- a/src/lib/pages/history/search-form.svelte
+++ b/src/lib/pages/history/search-form.svelte
@@ -146,22 +146,34 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 4px;
+    width: 560px;
 
     :global(.sui.toolbar) {
-      justify-content: flex-start;
+      flex-wrap: wrap;
+      justify-content: center;
       gap: 4px;
       width: 100%;
+      height: auto;
+      min-height: var(--toolbar-size);
+      white-space: nowrap;
 
       :global(.sui.button.medium) {
         gap: 0;
         --button--medium--padding: 0 8px;
       }
     }
+
+    @media (max-width: 1023px) {
+      order: 1;
+      width: 100%;
+    }
   }
 
   .terms {
+    width: 100%;
+
     :global(.search-bar) {
-      width: 560px;
+      width: 100%;
       --input--medium--border-radius: 32px;
     }
   }

--- a/src/lib/pages/layouts/history-layout.svelte
+++ b/src/lib/pages/layouts/history-layout.svelte
@@ -45,9 +45,13 @@
     z-index: 1;
     flex: none;
     display: flex;
-    gap: 32px;
+    gap: 16px 32px;
     justify-content: flex-start;
     align-items: flex-start;
+
+    @media (max-width: 1023px) {
+      flex-wrap: wrap;
+    }
 
     h1 {
       margin: 0;

--- a/src/lib/pages/onboarding/no-history.svelte
+++ b/src/lib/pages/onboarding/no-history.svelte
@@ -45,8 +45,17 @@
     gap: 64px;
     min-height: 400px;
 
+    @media (max-width: 1023px) {
+      flex-direction: column;
+    }
+
     .col {
       width: calc(50% - 16px);
+
+      @media (max-width: 1023px) {
+        width: 100%;
+        max-width: 640px;
+      }
     }
   }
 

--- a/src/lib/pages/onboarding/onboarding-tour.svelte
+++ b/src/lib/pages/onboarding/onboarding-tour.svelte
@@ -81,9 +81,18 @@
     gap: 64px;
     min-height: 400px;
 
+    @media (max-width: 1023px) {
+      flex-direction: column;
+    }
+
     .col:last-of-type {
       flex: none;
       width: 40%;
+
+      @media (max-width: 1023px) {
+        width: 100%;
+        max-width: 640px;
+      }
     }
   }
 
@@ -111,6 +120,7 @@
 
   img {
     width: 100%;
+    max-width: 560px;
   }
 
   .extra {


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/890

オンボーディングツアーと検索ページのレイアウトを横幅 768px ぐらいでも収まるように調整しました。

<img width="800" alt="image" src="https://github.com/videomark/videomark/assets/2929505/735155d1-1ff4-49d3-a178-552e5e449a34">
