### PR TITLE
Youtubeミニプレーヤー時のurl取得改善 #423

### DIFF
--- a/src/lib/content/sodium/modules/GeneralTypeHandler.js
+++ b/src/lib/content/sodium/modules/GeneralTypeHandler.js
@@ -75,7 +75,7 @@ export default class GeneralTypeHandler {
     return [];
   }
 
-  get_alt_location(){
+  get_alt_location() {
     return '';
   }
 

--- a/src/lib/content/sodium/modules/GeneralTypeHandler.js
+++ b/src/lib/content/sodium/modules/GeneralTypeHandler.js
@@ -75,6 +75,10 @@ export default class GeneralTypeHandler {
     return [];
   }
 
+  get_alt_location(){
+    return '';
+  }
+
   /**
    * @return {number[] | Array<{
    *  representationId: string,

--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -500,7 +500,10 @@ export default class SessionData {
 
     await storage.save({
       user_agent: this.userAgent,
-      location: this.alt_location || this.location.href,
+      location:
+        this.alt_location ||
+        video.video_handler.get_alt_location(this.location.href) ||
+        this.location.href,
       transfer_size: resource.transferSize,
       media_size: video.get_media_size(),
       domain_name: video.get_domain_name(),

--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -224,10 +224,10 @@ export default class SessionData {
       console.log(`VIDEOMARK: STATE CHANGE found main video ${mainVideo.get_video_id()}`);
       this.location = new URL(window.location.href);
 
-      if(this.alt_location === undefined){
+      if (this.alt_location === undefined) {
         this.alt_location = mainVideo.video_handler.get_alt_location(this.location.href);
       }
-      
+
       try {
         startTime = await this.waitPlay(mainVideo);
 

--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -224,6 +224,10 @@ export default class SessionData {
       console.log(`VIDEOMARK: STATE CHANGE found main video ${mainVideo.get_video_id()}`);
       this.location = new URL(window.location.href);
 
+      if(this.alt_location === undefined){
+        this.alt_location = mainVideo.video_handler.get_alt_location(this.location.href);
+      }
+      
       try {
         startTime = await this.waitPlay(mainVideo);
 
@@ -525,6 +529,8 @@ export default class SessionData {
         .sort(({ date: ad }, { date: bd }) => ad - bd)
         .slice(-Config.max_log),
     });
+
+    this.alt_location = undefined;
 
     await saveTransferSize(resource.transferSize - prevResource.transferSize);
   }

--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -224,10 +224,6 @@ export default class SessionData {
       console.log(`VIDEOMARK: STATE CHANGE found main video ${mainVideo.get_video_id()}`);
       this.location = new URL(window.location.href);
 
-      if (this.alt_location === undefined) {
-        this.alt_location = mainVideo.video_handler.get_alt_location(this.location.href);
-      }
-
       try {
         startTime = await this.waitPlay(mainVideo);
 
@@ -530,8 +526,6 @@ export default class SessionData {
         .slice(-Config.max_log),
     });
 
-    this.alt_location = undefined;
-
     await saveTransferSize(resource.transferSize - prevResource.transferSize);
   }
 
@@ -553,7 +547,10 @@ export default class SessionData {
       endTime: this.endTime,
       session: this.session.id,
       sessionType: this.session.type,
-      location: this.alt_location || this.location.href,
+      location:
+        this.alt_location ||
+        video.video_handler.get_alt_location(this.location.href) ||
+        this.location.href,
       locationIp: this.hostToIp[this.location.host],
       userAgent: this.userAgent,
       sequence: this.sequence,

--- a/src/lib/content/sodium/modules/VideoHandler.js
+++ b/src/lib/content/sodium/modules/VideoHandler.js
@@ -288,6 +288,10 @@ export default class VideoHandler {
     return video.getVideoPlaybackQuality().droppedVideoFrames;
   }
 
+  get_alt_location(url){
+    return this.handler.get_alt_location(url);
+  }
+
   is_main_video(video) {
     if (this.handler.is_main_video instanceof Function) {
       return this.handler.is_main_video(video);

--- a/src/lib/content/sodium/modules/VideoHandler.js
+++ b/src/lib/content/sodium/modules/VideoHandler.js
@@ -288,7 +288,7 @@ export default class VideoHandler {
     return video.getVideoPlaybackQuality().droppedVideoFrames;
   }
 
-  get_alt_location(url){
+  get_alt_location(url) {
     return this.handler.get_alt_location(url);
   }
 

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -92,13 +92,6 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
       // トップページ上部の広告動画はiframeになっているため、このurlは計測から除外する
       const url = new URL(window.location.href);
 
-      // let instance = new YouTubeTypeHandler(document.querySelector('video')); 
-      // let videoId_test = instance.get_id_by_video_holder(); 
-      
-      // if(url.href === 'https://www.youtube.com/'){
-      //   url.href = `https://www.youtube.com/watch?v=${videoId_test}`;
-      // }
-
       if (url.pathname === '/embed/') {
         return false;
       }
@@ -185,14 +178,6 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
 
   static async hook_youtube() {
     const { host } = new URL(window.location.href);
-
-    // let instance = new YouTubeTypeHandler(document.querySelector('video')); 
-    // let videoId_test = instance.get_id_by_video_holder(); 
-
-
-    // if(host.href === 'https://www.youtube.com/'){
-    //   host.href = `https://www.youtube.com/watch?v=${videoId_test}`;
-    // }
 
     if (!(host === 'www.youtube.com' || host === 'm.youtube.com')) {
       return;

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -88,8 +88,16 @@ const SodiumFetch = Symbol('SodiumFetch');
 class YouTubeTypeHandler extends GeneralTypeHandler {
   static is_youtube_type() {
     try {
+      
       // トップページ上部の広告動画はiframeになっているため、このurlは計測から除外する
       const url = new URL(window.location.href);
+
+      // let instance = new YouTubeTypeHandler(document.querySelector('video')); 
+      // let videoId_test = instance.get_id_by_video_holder(); 
+      
+      // if(url.href === 'https://www.youtube.com/'){
+      //   url.href = `https://www.youtube.com/watch?v=${videoId_test}`;
+      // }
 
       if (url.pathname === '/embed/') {
         return false;
@@ -177,6 +185,14 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
 
   static async hook_youtube() {
     const { host } = new URL(window.location.href);
+
+    // let instance = new YouTubeTypeHandler(document.querySelector('video')); 
+    // let videoId_test = instance.get_id_by_video_holder(); 
+
+
+    // if(host.href === 'https://www.youtube.com/'){
+    //   host.href = `https://www.youtube.com/watch?v=${videoId_test}`;
+    // }
 
     if (!(host === 'www.youtube.com' || host === 'm.youtube.com')) {
       return;
@@ -989,6 +1005,16 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
     const audio = formats.find((e) => e.itag === stats.afmt);
 
     return { video, audio };
+  }
+
+  get_alt_location(url){
+    let videoId;
+    if(url === 'https://www.youtube.com/'){
+      this.player = document.querySelector('#movie_player');
+      videoId = this.player.getVideoData();
+      return `https://www.youtube.com/watch?v=${videoId.video_id}`;
+    }
+    return '';
   }
 
   is_main_video(video) {

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -995,7 +995,6 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
     let videoId;
 
     if (url === 'https://www.youtube.com/') {
-      this.player = document.querySelector('#movie_player');
       videoId = this.player.getVideoData();
 
       return `https://www.youtube.com/watch?v=${videoId.video_id}`;

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -88,7 +88,6 @@ const SodiumFetch = Symbol('SodiumFetch');
 class YouTubeTypeHandler extends GeneralTypeHandler {
   static is_youtube_type() {
     try {
-      
       // トップページ上部の広告動画はiframeになっているため、このurlは計測から除外する
       const url = new URL(window.location.href);
 
@@ -992,13 +991,16 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
     return { video, audio };
   }
 
-  get_alt_location(url){
+  get_alt_location(url) {
     let videoId;
-    if(url === 'https://www.youtube.com/'){
+
+    if (url === 'https://www.youtube.com/') {
       this.player = document.querySelector('#movie_player');
       videoId = this.player.getVideoData();
+
       return `https://www.youtube.com/watch?v=${videoId.video_id}`;
     }
+
     return '';
   }
 


### PR DESCRIPTION
下記のケースでMongoDBのsodium_collection内にあるlocationと実際に再生していた動画が紐づいていることを確認
- ミニプレーヤーで再生
- ミニプレーヤーで再生中、トラックアップで次の動画を再生
- ミニプレーヤーで再生中、ミニプレーヤーモードを解除して、トラックアップで次の動画を再生