### PR TITLE
youtube.musicのミニプレーヤー再生時も再生中URLが取得できるように変更

### DIFF
--- a/src/lib/content/sodium/modules/VideoHandler.js
+++ b/src/lib/content/sodium/modules/VideoHandler.js
@@ -289,7 +289,11 @@ export default class VideoHandler {
   }
 
   get_alt_location(url) {
-    return this.handler.get_alt_location(url);
+    if (typeof this.handler.get_alt_location === 'function') {
+      return this.handler.get_alt_location(url);
+    }
+
+    return '';
   }
 
   is_main_video(video) {

--- a/src/lib/content/sodium/modules/VideoHandler.js
+++ b/src/lib/content/sodium/modules/VideoHandler.js
@@ -289,11 +289,7 @@ export default class VideoHandler {
   }
 
   get_alt_location(url) {
-    if (typeof this.handler.get_alt_location === 'function') {
-      return this.handler.get_alt_location(url);
-    }
-
-    return '';
+    return this.handler.get_alt_location(url);
   }
 
   is_main_video(video) {

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -993,14 +993,12 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
 
   get_alt_location(url) {
     const videoId = this.player.getVideoData();
-    
+
     if (url === 'https://www.youtube.com/') {
-      
       return `https://www.youtube.com/watch?v=${videoId.video_id}`;
     }
-    
-    if (url !== `https://music.youtube.com/watch?v=${videoId.video_id}`) {
 
+    if (url !== `https://music.youtube.com/watch?v=${videoId.video_id}`) {
       return `https://music.youtube.com/watch?v=${videoId.video_id}`;
     }
 

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -992,12 +992,16 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
   }
 
   get_alt_location(url) {
-    let videoId;
-
+    const videoId = this.player.getVideoData();
+    
     if (url === 'https://www.youtube.com/') {
-      videoId = this.player.getVideoData();
-
+      
       return `https://www.youtube.com/watch?v=${videoId.video_id}`;
+    }
+    
+    if (url !== `https://music.youtube.com/watch?v=${videoId.video_id}`) {
+
+      return `https://music.youtube.com/watch?v=${videoId.video_id}`;
     }
 
     return '';

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -992,14 +992,14 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
   }
 
   get_alt_location(url) {
-    const videoId = this.player.getVideoData();
+    const { video_id: videoId } = this.player.getVideoData();
 
     if (url === 'https://www.youtube.com/') {
-      return `https://www.youtube.com/watch?v=${videoId.video_id}`;
+      return `https://www.youtube.com/watch?v=${videoId}`;
     }
 
-    if (url !== `https://music.youtube.com/watch?v=${videoId.video_id}`) {
-      return `https://music.youtube.com/watch?v=${videoId.video_id}`;
+    if (new URL(url).origin === 'https://music.youtube.com') {
+      return `https://music.youtube.com/watch?v=${videoId}`;
     }
 
     return '';


### PR DESCRIPTION
https://github.com/videomark/videomark/pull/223 と同様の内容をYoutube.musicでも確認

具体的には下記
MongoDBのsodium_collection内にあるlocationと実際に再生していた動画が紐づいていることを確認
- ミニプレーヤーで再生
- ミニプレーヤーで再生中、トラックアップで次の動画を再生
- ミニプレーヤーで再生中、ミニプレーヤーモードを解除して、トラックアップで次の動画を再生