### PR TITLE
計測時間上限の設定メニューが日本語になっている問題を修正

### DIFF
--- a/src/lib/components/stats/stats-body.svelte
+++ b/src/lib/components/stats/stats-body.svelte
@@ -17,7 +17,7 @@
   export let log = {};
 
   $: ({ isLowQuality } = stats);
-  $: formattedStats = formatStats(locale, stats);
+  $: formattedStats = formatStats($locale, stats);
 </script>
 
 <table>

--- a/src/lib/pages/history/detail-panel.svelte
+++ b/src/lib/pages/history/detail-panel.svelte
@@ -63,7 +63,7 @@
           {@const { key, region = {}, startTime, stats } = item}
           {@const { qoe, isLowQuality } = stats}
           {@const { country, subdivision } = region ?? {}}
-          {@const formattedStats = formatStats(locale, stats)}
+          {@const formattedStats = formatStats($locale, stats)}
           {@const deleted = $deletedHistoryItemKeys.includes(key)}
           <Group class="view-item">
             <div class="header">

--- a/src/lib/pages/routes/settings.svelte
+++ b/src/lib/pages/routes/settings.svelte
@@ -37,7 +37,7 @@
       maxVideoTTLs = [5, 10, 20, 30, 60] // min
         .map((min) => ({
           value: min * 60 * 1000, // msec
-          label: new Intl.NumberFormat('ja', { style: 'unit', unit: 'minute' }).format(min),
+          label: new Intl.NumberFormat($locale, { style: 'unit', unit: 'minute' }).format(min),
         }));
 
       resolutions = [0, 144, 240, 360, 480, 720, 1080, 1440, 2160].map((v) => ({


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/915

- `ja` ロケールがハードコーディングされているのを修正
- その他 2 つ、コード上のミスで `$locale` が `locale` になっている問題を修正
  - #228 で混入したミス
  - UI 上は問題にはなっていないようですが