### PR TITLE
ニコニコ生放送の正規表現修正、エラー時にコンソールに内容を表示するように修正

### DIFF
--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -202,6 +202,7 @@ export default class SessionData {
         video.push(new_video);
       } catch (err) {
         // どのタイプでもない
+        console.error(err);
       }
     });
 

--- a/src/lib/content/sodium/modules/VideoHandler.js
+++ b/src/lib/content/sodium/modules/VideoHandler.js
@@ -33,7 +33,7 @@ export default class VideoHandler {
       this.handler = new NicoVideoTypeHandler(elm);
       this.service = 'nicovideo';
       console.log('NicoVideo Type Handler');
-    } else if (/live\d.nicovideo.jp/.test(url.host)) {
+    } else if (/live\.nicovideo\.jp/.test(url.host)) {
       this.handler = new NicoLiveTypeHandler(elm);
       this.service = 'nicolive';
       console.log('NicoLive Type Handler');


### PR DESCRIPTION
ニコニコ生放送に関してはvideoオブジェクトの生成が上手くいってなかったらしく、
正規表現の修正でオーバーレイ表示が上手くいくようになりました。
なので、config.jsでのニコニコ生放送のDOM要素の指定は変更せずconfig.uiの設定を使用しています。
