### PR TITLE
自動計測向けの初期設定

### DIFF
--- a/src/lib/pages/routes/settings.svelte
+++ b/src/lib/pages/routes/settings.svelte
@@ -123,9 +123,19 @@
       const expiresIn = 10 * 365 * 24 * 60 * 60 * 1000;
 
       await overwritePersonalSession(sessionId, expiresIn);
-      settings.update((_settings) => ({ ...(_settings ?? {}), expires_in: expiresIn }));
+
+      $settings.expires_in = expiresIn;
     }
   });
+
+  $: {
+    // 自動計測向けの初期設定
+    const bot = new URLSearchParams(window.location.search).get('bot') === 'true';
+
+    if ($settings.show_latest_qoe_enabled && bot) {
+      $settings.show_latest_qoe_enabled = false;
+    }
+  }
 
   $: $session.type = getSessionType($session.id);
   $: $session.expires = Date.now() + $settings.expires_in;


### PR DESCRIPTION
- https://github.com/webdino/sodium/issues/936

拡張機能の `/index.html?bot=true&session_id=${sessionId}#settings` にアクセスすることで、QoE問い合わせを停止する機能を提供します。

- 最新QoE値を非表示
