### PR TITLE
オンボーディングページが更新時に毎回開かれる問題を修正

### DIFF
--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -80,23 +80,22 @@ const initToolbarButton = async () => {
 
 initToolbarButton();
 
-chrome.runtime.onInstalled.addListener(() => {
-  (async () => {
-    const termsAgreed = await storage.get('AgreedTerm');
+chrome.runtime.onInstalled.addListener(async ({ reason }) => {
+  if (reason === 'install') {
+    openTab('#/onboarding');
+  }
+
+  if (reason === 'update') {
+    const termsAgreed = (await storage.get('AgreedTerm')) || false;
     const version = await storage.get('version');
     const legacyVersion = version && version < SCHEMA_VERSION;
 
-    // 古いデータスキーマの場合は移行せずに破棄
+    // 古いデータスキーマの場合は移行せず、利用規約同意有無のみ残して破棄
     if (legacyVersion) {
       await storage.clear();
+      await storage.set('AgreedTerm', termsAgreed);
     }
-
-    if (termsAgreed && !legacyVersion) {
-      chrome.action.setPopup({ popup: '/index.html#/popup' });
-    } else {
-      openTab('#/onboarding');
-    }
-  })();
+  }
 });
 
 const getMasterDisplayOnPlayer = async () => {


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/953

 [`runtime.onInstalled`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled) コールバック関数の引数として渡される `reason` を見て、拡張機能インストール時のみオンボーディングページを開き、拡張機能更新時のみスキーマバージョンを確認するようにします。ツールバーボタンの挙動変更 (`chrome.action.setPopup`) は直前の `initToolbarButton` 内で重複して行っているので削除します。