### PR TITLE
ci: キャッシュのキーとして pnpm-lock.yaml のハッシュ値を使用するように変更

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: pnpm install
       - run: pnpm build
       - run: pnpm exec playwright install --with-deps


### PR DESCRIPTION
package-lock.json のハッシュ値が使用されていましたが、package-lock.json はこのコードベース内には存在しません。 代わりに pnpm-lock.yaml ハッシュ値を使用するように変更します