### PR TITLE
build(firefox): MV3対応のFirefox v109を最小バージョンとして指定

### DIFF
--- a/public/manifest-firefox.json
+++ b/public/manifest-firefox.json
@@ -8,7 +8,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "videomark@webdino.org",
-      "strict_min_version": "78.0"
+      "strict_min_version": "109.0"
     }
   },
   "options_ui": {


### PR DESCRIPTION
Firefoxのmanifest.jsonのstrict\_min\_versionを更新しています。
アドオンの検証で警告が出ていたためです。

https://addons.mozilla.org/ja/developers/addon/videomark/versions

警告・通知の一覧

```
Manifest V3 compatibility warning

警告: Firefox is adding support for manifest version 3 (MV3) extensions in Firefox 109.0, however, older versions of Firefox are only compatible with manifest version 2 (MV2) extensions. We recommend uploading Manifest V3 extensions as self-hosted for now to not break compatibility for your users.

For more information about the MV3 extension roll-out or self-hosting MV3 extensions, visit https://mzl.la/3hIwQXX
Manifest key not supported by the specified minimum Firefox version

警告: "strict_min_version" requires Firefox 78, which was released before version 109 introduced support for "action".
manifest.json
Manifest key not supported by the specified minimum Firefox for Android version

警告: "strict_min_version" requires Firefox for Android 78, which was released before version 109 introduced support for "action".
manifest.json
Manifest key not supported by the specified minimum Firefox version

警告: "strict_min_version" requires Firefox 78, which was released before version 109 introduced support for "action.default_icon".
manifest.json
Manifest key not supported by the specified minimum Firefox version

警告: "strict_min_version" requires Firefox 78, which was released before version 109 introduced support for "host_permissions".
manifest.json
Manifest key not supported by the specified minimum Firefox for Android version

警告: "strict_min_version" requires Firefox for Android 78, which was released before version 109 introduced support for "host_permissions".
manifest.json
Unsafe assignment to innerHTML

警告: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.
assets/index-e1a9de1c.js 行: 1 列: 3925
action.setPopup is not supported in Firefox version 78.0

警告: This API is not implemented by the given minimum Firefox version
scripts/background.js 行: 1 列: 1170
action.setPopup is not supported in Firefox for Android version 78.0

警告: This API is not implemented by the given minimum Firefox for Android version
scripts/background.js 行: 1 列: 1170
action.onClicked is not supported in Firefox version 78.0

警告: This API is not implemented by the given minimum Firefox version
scripts/background.js 行: 1 列: 1223
action.onClicked is not supported in Firefox for Android version 78.0

警告: This API is not implemented by the given minimum Firefox for Android version
scripts/background.js 行: 1 列: 1223
action.setIcon is not supported in Firefox version 78.0

警告: This API is not implemented by the given minimum Firefox version
scripts/background.js 行: 1 列: 2393
action.setIcon is not supported in Firefox for Android version 78.0

警告: This API is not implemented by the given minimum Firefox for Android version
scripts/background.js 行: 1 列: 2393
Unsafe assignment to innerHTML

警告: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.
scripts/pages.js 行: 3 列: 41441
Unsafe assignment to innerHTML

警告: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.
scripts/pages.js 行: 3 列: 41588
Unsafe assignment to innerHTML

警告: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.
scripts/pages.js 行: 3 列: 44268
Unsafe assignment to innerHTML

警告: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.
scripts/pages.js 行: 3 列: 44568
action.setPopup is not supported in Firefox version 78.0

警告: This API is not implemented by the given minimum Firefox version
scripts/pages.js 行: 3 列: 45746
action.setPopup is not supported in Firefox for Android version 78.0

警告: This API is not implemented by the given minimum Firefox for Android version
scripts/pages.js 行: 3 列: 45746
Unsafe assignment to innerHTML

警告: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.
scripts/pages.js 行: 3 列: 79401
Unsafe assignment to innerHTML

警告: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.
scripts/pages.js 行: 3 列: 81305
Permission not supported by the specified minimum Firefox version

通知: "strict_min_version" requires Firefox 78, which was released before version 113 introduced support for "permissions:declarativeNetRequestWithHostAccess".
manifest.json
Permission not supported by the specified minimum Firefox for Android version

通知: "strict_min_version" requires Firefox for Android 78, which was released before version 113 introduced support for "permissions:declarativeNetRequestWithHostAccess".
manifest.json
```
