### PR TITLE
Firefox の Manifest V3 対応をバックアウト

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -18,10 +18,10 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
     // {
     //   name: 'webkit',
     //   use: { ...devices['Desktop Safari'] },

--- a/public/manifest-firefox.json
+++ b/public/manifest-firefox.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "Web VideoMark",
   "version": "2.6.1",
   "description": "Web VideoMark 拡張機能 - 動画配信サービス視聴時の品質情報を計測します。",
@@ -29,12 +29,9 @@
     "webRequestBlocking",
     "storage",
     "unlimitedStorage",
-    "declarativeNetRequestWithHostAccess"
-  ],
-  "host_permissions": [
     "<all_urls>"
   ],
-  "action": {
+  "browser_action": {
     "default_icon": "images/icons/disabled.png"
   },
   "content_scripts": [
@@ -62,14 +59,7 @@
     "page": "background.html"
   },
   "web_accessible_resources": [
-    {
-      "resources": [
-        "scripts/sodium.js",
-        "assets/*"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
-    }
+    "scripts/sodium.js",
+    "assets/*"
   ]
 }

--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -72,7 +72,7 @@ const initToolbarButton = async () => {
   const termsAgreed = await storage.get('AgreedTerm');
 
   if (termsAgreed) {
-    chrome.action.setPopup({ popup: '/index.html#/popup' });
+    (chrome.action ?? chrome.browserAction).setPopup({ popup: '/index.html#/popup' });
   } else {
     chrome.action.onClicked.addListener(() => openTab('#/onboarding'));
   }
@@ -165,7 +165,7 @@ const updateIcon = async (tabId, enabled) => {
   status.alive = enabled;
   await storage.set('tabStatus', { ...tabStatus, [tabId]: status });
 
-  chrome.action.setIcon({
+  (chrome.action ?? chrome.browserAction).setIcon({
     tabId,
     path: enabled ? '/images/icons/enabled.png' : '/images/icons/disabled.png',
   });

--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -74,7 +74,7 @@ const initToolbarButton = async () => {
   if (termsAgreed) {
     (chrome.action ?? chrome.browserAction).setPopup({ popup: '/index.html#/popup' });
   } else {
-    chrome.action.onClicked.addListener(() => openTab('#/onboarding'));
+    (chrome.action ?? chrome.browserAction).onClicked.addListener(() => openTab('#/onboarding'));
   }
 };
 

--- a/src/lib/pages/onboarding/onboarding-tour.svelte
+++ b/src/lib/pages/onboarding/onboarding-tour.svelte
@@ -13,7 +13,7 @@
 
   const agreeTerms = () => {
     storage.set('AgreedTerm', true);
-    chrome.action.setPopup({ popup: '/index.html#/popup' });
+    (chrome.action ?? chrome.browserAction).setPopup({ popup: '/index.html#/popup' });
     window.location.replace('#/history');
   };
 </script>

--- a/src/lib/pages/popup/popup-history.svelte
+++ b/src/lib/pages/popup/popup-history.svelte
@@ -23,7 +23,11 @@
 
   onMount(() => {
     (async () => {
-      const tabUrls = (await chrome.tabs.query({ currentWindow: true })).map(({ url }) => url);
+      const tabUrls = await new Promise((resolve) => {
+        chrome.tabs.query({ currentWindow: true }, (tabs) => {
+          resolve(tabs.map(({ url }) => url));
+        });
+      });
 
       playingVideos = history.filter((item) => tabUrls.includes(item.url));
     })();

--- a/src/lib/services/navigation.js
+++ b/src/lib/services/navigation.js
@@ -15,9 +15,16 @@ export const openTab = async (url) => {
     url = chrome.runtime.getURL(url.replace(/^#/, '/index.html#'));
   }
 
-  const [currentTab] = await chrome.tabs.query({
-    currentWindow: true,
-    url: isInternalPage ? `${chrome.runtime.getURL('/')}*` : url,
+  const [currentTab] = await new Promise((resolve) => {
+    chrome.tabs.query(
+      {
+        currentWindow: true,
+        url: isInternalPage ? `${chrome.runtime.getURL('/')}*` : url,
+      },
+      (tabs) => {
+        resolve(tabs);
+      },
+    );
   });
 
   if (currentTab) {

--- a/src/lib/services/storage.js
+++ b/src/lib/services/storage.js
@@ -66,11 +66,19 @@ export class storage {
   }
 
   static async get(key) {
-    return (await this.localStorage.get([key]))[key];
+    return new Promise((resolve) => {
+      this.localStorage.get([key], (obj) => {
+        resolve(obj[key]);
+      });
+    });
   }
 
   static async getAll() {
-    return this.localStorage.get();
+    return new Promise((resolve) => {
+      this.localStorage.get(null, (obj) => {
+        resolve(obj);
+      });
+    });
   }
 
   static async set(key, value) {


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/957

- Firefox のみ Manifest V2 に戻して、計測が自動的に始まらない問題を回避します。
- 一部 V2 と V3 で互換性がないので、共存可能なようにコードを変更します。
- デスクトップ版 Firefox が自動テスト対象になっていなかったので有効化しました。