### PR TITLE
Lemino 対応を Firefox 向けマニフェストに追加

### DIFF
--- a/public/manifest-firefox.json
+++ b/public/manifest-firefox.json
@@ -46,7 +46,7 @@
         "*://*.fod.fujitv.co.jp/*",
         "*://fod.fujitv.co.jp/*",
         "*://*.nhk-ondemand.jp/*",
-        "*://*.video.dmkt-sp.jp/*",
+        "*://lemino.docomo.ne.jp/*",
         "*://abema.tv/*",
         "*://*.amazon.co.jp/*",
         "*://pr.iij.ad.jp/*",


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/960

#240 で `manifest-firefox.json` のみ更新されていなかったため、そのフォローアップです。