### PR TITLE
計測 ID が空になる場合がある問題を修正

### DIFF
--- a/src/lib/pages/routes/settings.svelte
+++ b/src/lib/pages/routes/settings.svelte
@@ -208,7 +208,7 @@
           }
         }}
       >
-        <SettingItem title={$_('settings.sessionId')}>
+        <SettingItem id="session-id" title={$_('settings.sessionId')}>
           {$session.id || ''}
         </SettingItem>
       </div>

--- a/src/lib/pages/settings/setting-item.svelte
+++ b/src/lib/pages/settings/setting-item.svelte
@@ -1,17 +1,19 @@
 <script>
+  /** @type {string} */
+  export let id;
   export let title = '';
   export let description = '';
 </script>
 
-<section>
+<section id={id ? `setting-${id}` : undefined}>
   <div class="row">
     <div>
-      <h3>{title}</h3>
+      <h3 id={id ? `setting-${id}-title` : undefined}>{title}</h3>
       {#if description}
         <p>{description}</p>
       {/if}
     </div>
-    <div>
+    <div id={id ? `setting-${id}-value` : undefined}>
       <slot />
     </div>
   </div>

--- a/src/lib/services/sessions.js
+++ b/src/lib/services/sessions.js
@@ -1,7 +1,13 @@
+import { get } from 'svelte/store';
 import { validate, version } from 'uuid';
+import { settings } from '$lib/services/settings';
 import { createStorageSync, storage } from '$lib/services/storage';
 
-export const session = createStorageSync('session', {});
+export const session = createStorageSync('session', {
+  id: window.crypto.randomUUID(),
+  type: 'social',
+  expires: Date.now() + get(settings).expires_in,
+});
 
 // NOTE: サーバー側で "_" が使えない
 const allowedPattern = /^[0-9A-Za-z.-]+$/;

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -16,6 +16,10 @@ test.describe('拡張機能内ページ', () => {
     // 設定ページを開く
     await page.getByRole('button', { name: 'Settings' }).click();
     await expect(page).toHaveURL(/#\/settings$/);
+    // セッション ID が設定されていることを確認
+    await expect(page.locator('#setting-session-id-value')).toHaveText(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
 
     // 履歴ページへ戻る
     await page.getByRole('button', { name: 'Back to History' }).click();


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/969

この修正で、最初に UI (オンボーディングツアー) が読み込まれた時点でセッションが作成されて、ID が空になったりタイプが `personal` に変わったりすることはなくなります。本来は利用規約同意後に作成されるのが望ましいのかもしれませんが、センシティブな情報が含まれているわけでもないですし、後日全体リファクタリング時に見直したいと思います。今は #251 が優先なので、最低限の修正です。