### PR TITLE
YouTube で毎秒 delete video / new video found メッセージが出る問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -176,6 +176,11 @@ export default class SessionData {
     const video = [];
 
     Array.from(elms).forEach((elm) => {
+      // 表示されていない要素は無視
+      if (!elm.offsetWidth) {
+        return;
+      }
+
       // 有効期限内かつソースの変わらない既存の要素はそのまま
       const v = this.video.find(
         (e) =>


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/965

今日のミーティング中に話しましたが、(動画 →) チャンネルトップ → 動画 のページ遷移で必ず発生するようで、チャンネルトップの動画が非表示のまま DOM 上に残り、それが毎秒のチェックに引っ掛かっていることが原因でした。単純に非表示の `video` 要素を無視することで回避します。