### PR TITLE
TVer 視聴履歴の問題を修正

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -55,11 +55,12 @@ words:
   - Kagawa
   - Kanagawa
   - kbps
+  - lemino
   - Mbps
+  - mediainfo
   - Miyagi
   - Miyazaki
   - msgpack
-  - lemino
   - netinfo
   - nhkondemand
   - nicolive


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/812

動画のサムネイルとタイトルが正しく記録されるようにします。

また、関連動画を開いたときに計測が始まらない問題を解消します。(実はどの部分で修正されたのか分かっていませんが)