### PR TITLE
視聴履歴で QoE 値の小数点以下が切り捨てられている問題を修正

### DIFF
--- a/src/lib/pages/history/history-item.svelte
+++ b/src/lib/pages/history/history-item.svelte
@@ -108,7 +108,7 @@
           {:else}
             <Icon name="equalizer" />
           {/if}
-          {qoe}
+          {qoe.toFixed(2)}
         {/if}
       </div>
       <div class="actions close-popup">

--- a/src/lib/pages/history/quality-bar.svelte
+++ b/src/lib/pages/history/quality-bar.svelte
@@ -15,7 +15,7 @@
       style:background-color="hsl({percent}, 70%, 40%)"
     />
   </div>
-  <div class="number">{value}</div>
+  <div class="number">{value.toFixed(2)}</div>
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/987

小数第 2 位まで必ず表示されるようにします。