### PR TITLE
YouTube でスループットが取得できていない問題を修正

### DIFF
--- a/src/lib/components/stats/stats-row.svelte
+++ b/src/lib/components/stats/stats-row.svelte
@@ -26,10 +26,10 @@
   export let chartData = [];
 </script>
 
-{#if displayValue !== null}
+{#if displayValue !== null || chartData.some(Boolean)}
   <tr>
     <th scope="row">{label}</th>
-    <td>{displayValue}</td>
+    <td>{displayValue ?? '–'}</td>
     <td>
       <StatsChart {prop} {chartData} />
     </td>

--- a/src/lib/services/history.js
+++ b/src/lib/services/history.js
@@ -71,6 +71,15 @@ export const viewingHistory = writable(undefined, (set) => {
         } = item;
 
         const { hostname } = new URL(url);
+
+        /** @type {number[]} */
+        const throughputList = log
+          .filter((entry) => !!entry.quality?.throughput.length)
+          .map((entry) => entry.quality.throughput[0].throughput);
+
+        const averageThroughput =
+          throughputList.reduce((acc, cur) => acc + cur, 0) / throughputList.length;
+
         const latestStats = log.findLast((entry) => !!entry.quality)?.quality || {};
         const provisionalQoe = log.findLast((entry) => !!entry.qoe)?.qoe || -1;
         const qoe = Number.isFinite(finalQoe) ? finalQoe : provisionalQoe;
@@ -90,6 +99,7 @@ export const viewingHistory = writable(undefined, (set) => {
           region,
           stats: {
             ...latestStats,
+            throughput: averageThroughput,
             qoe,
             isLowQuality: Number.isFinite(qoe) && droppedVideoFrames / totalVideoFrames > 0.001,
             transferSize,

--- a/src/lib/services/stats.js
+++ b/src/lib/services/stats.js
@@ -122,7 +122,7 @@ export const formatStats = (locale, details) => {
 
   return {
     bitrate: isValidNumber(bitrate) ? `${formatKiloSize(locale, bitrate)} kbps` : null,
-    throughput: isValidNumber(throughput) ? `${formatKiloSize(locale, throughput)} kbps` : null,
+    throughput: isValidNumber(throughput) ? `${formatMegaSize(locale, throughput)} Mbps` : null,
     transferSize: isValidNumber(transferSize) ? `${formatMegaSize(locale, transferSize)} MB` : null,
     resolution:
       isValidNumber(videoWidth) && isValidNumber(videoHeight)


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1035

- `content-length` ヘッダーと `itag` クエリパラメーターが削除されているので、それぞれ別の方法で取得
- オーバーレイのスループット行が常時表示されない問題を修正
- 計測結果のスループットが表示されない問題を修正 (平均値として表示)
- 表示単位を kbps から Mbps へ変更