### PR TITLE
YouTube 埋め込み動画で VideoMark が作動してしまっている問題を修正

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -37,7 +37,7 @@
       "js": [
         "scripts/content.js"
       ],
-      "all_frames": true
+      "all_frames": false
     }
   ],
   "background": {


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1053

YouTube に限らず `iframe` を使った埋め込み動画の計測に対応しているサービスはないはずなので、[`content_scripts`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) の `all_frames` オプションを無効化して計測対象から除外します。