### PR TITLE
ABEMA 生放送の計測失敗を修正

### DIFF
--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -422,7 +422,7 @@ Config.ui.abematv = {
     left: 65px;
   }
   @media (any-pointer: fine) {
-    #${Config.ui.id}:not(:hover){
+    :is(.com-tv-TVScreen__player-container, .com-vod-VODScreen-container):not(:hover) > #${Config.ui.id} {
       opacity: 0;
     }
   }`,

--- a/src/lib/content/sodium/modules/VideoHandler.js
+++ b/src/lib/content/sodium/modules/VideoHandler.js
@@ -267,18 +267,10 @@ export default class VideoHandler {
   }
 
   get_total_frames(video) {
-    if (this.handler instanceof AbemaTVLiveTypeHandler) {
-      return this.handler.get_total_frames();
-    }
-
     return video.getVideoPlaybackQuality().totalVideoFrames;
   }
 
   get_dropped_frames(video) {
-    if (this.handler instanceof AbemaTVLiveTypeHandler) {
-      return this.handler.get_dropped_frames();
-    }
-
     return video.getVideoPlaybackQuality().droppedVideoFrames;
   }
 


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/955
Fix https://github.com/webdino/sodium/issues/1051

- CM 判定が難しいため `is_cm()` は常に `false` を返すように
- 現状 `<video>` 要素はひとつしかないのでコードを簡素化
- 内部エラー「ignore this video」を修正
- サムネイルが取得できていない問題を修正
- 動画へのマウスホバーで計測オーバーレイを表示するよう CSS を修正