### PR TITLE
Firefox で拡張機能のドロップダウンが表示されない問題を修正

### DIFF
--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -16,6 +16,7 @@ const isPermittedOrigin = (origin) =>
 // 実装されていない Firefox 向け後方互換。 @see https://bugzilla.mozilla.org/1687755
 if (typeof chrome.declarativeNetRequest === 'undefined') {
   chrome.webRequest.onHeadersReceived.addListener(
+    // Chrome は `initiator`、Firefox は `originUrl` を渡してくるので、両方に対応する
     ({ originUrl, initiator = new URL(originUrl).origin, responseHeaders }) => {
       const additionalHeaders = [
         isPermittedOrigin(initiator) && {

--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -16,7 +16,7 @@ const isPermittedOrigin = (origin) =>
 // 実装されていない Firefox 向け後方互換。 @see https://bugzilla.mozilla.org/1687755
 if (typeof chrome.declarativeNetRequest === 'undefined') {
   chrome.webRequest.onHeadersReceived.addListener(
-    ({ initiator, responseHeaders }) => {
+    ({ originUrl, initiator = new URL(originUrl).origin, responseHeaders }) => {
       const additionalHeaders = [
         isPermittedOrigin(initiator) && {
           name: 'Timing-Allow-Origin',

--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -16,7 +16,8 @@ const isPermittedOrigin = (origin) =>
 // 実装されていない Firefox 向け後方互換。 @see https://bugzilla.mozilla.org/1687755
 if (typeof chrome.declarativeNetRequest === 'undefined') {
   chrome.webRequest.onHeadersReceived.addListener(
-    // Chrome は `initiator`、Firefox は `originUrl` を渡してくるので、両方に対応する
+    // Firefox の古いバージョンは Chrome と同じ `initiator` を実装しているが、新しいバージョンでは `originUrl`
+    // に置き換わっているので、両方に対応する
     ({ originUrl, initiator = new URL(originUrl).origin, responseHeaders }) => {
       const additionalHeaders = [
         isPermittedOrigin(initiator) && {

--- a/src/lib/services/runtime.js
+++ b/src/lib/services/runtime.js
@@ -57,7 +57,12 @@ export const isSmallScreen = readable(false, (set) => {
 export const isPopupOpen = async () => {
   // Manifest v3
   if (typeof chrome.runtime.getContexts === 'function') {
-    return !!(await chrome.runtime.getContexts({ contextTypes: ['POPUP'] })).length;
+    const contexts = await chrome.runtime.getContexts({ contextTypes: ['POPUP'] });
+
+    // Firefox では `undefined` が返されることがあるため要判定
+    if (Array.isArray(contexts)) {
+      return !!contexts.length;
+    }
   }
 
   // Manifest v2


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1055

Firefox では引き続き Manifest v3 の実装が進められていますが、その過程で非互換が生じてしまっているようです。2 つ問題を確認したので取り急ぎ修正します。手元では Developer Edition (v128) を使っています。

1. `chrome.runtime.getContexts()` が実装されたものの `undefined` を返している ([実装このあたり](https://bugzilla.mozilla.org/show_bug.cgi?id=1875480))
2. `chrome.webRequest.onHeadersReceived.addListener()` で渡されるオブジェクトから `initiator` が消えている (いつからかは未調査)