### PR TITLE
TVer で一部動画のサムネイルが表示されない問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/TVerTypeHandler.js
+++ b/src/lib/content/sodium/modules/TVerTypeHandler.js
@@ -96,6 +96,12 @@ export default class TVerTypeHandler {
   }
 
   static get_video_thumbnail() {
+    const ogImage = document.querySelector('meta[property="og:image"]')?.content ?? '';
+
+    if (ogImage && ogImage !== 'https://tver.jp/img/ogimg.png') {
+      return ogImage;
+    }
+
     return `https://statics.tver.jp/images/content/thumbnail/episode/small/${this.#videoSlug}.jpg`;
   }
 


### PR DESCRIPTION
一部のと言ってもパリ五輪の動画でしか確認できていませんが、通常の動画と異なり `og:image` が設定されていて、別オリジン (`https://olympic-assets.tver.jp`) に画像が配置されているので、そこから取得するようにします。