### PR TITLE
YouTube で計測オーバーレイが展開されない問題を修正

### DIFF
--- a/src/lib/components/stats/stats-body.svelte
+++ b/src/lib/components/stats/stats-body.svelte
@@ -22,9 +22,9 @@
 
 <table>
   <colgroup>
-    <col />
-    <col />
-    <col />
+    {#each ['key', 'value', 'chart'] as className}
+      <col class={className} />
+    {/each}
   </colgroup>
   {#each Object.entries(formattedStats) as [prop, displayValue] (prop)}
     <StatsRow {prop} label={$_(`stats.${prop}`)} {displayValue} chartData={log[prop]} />

--- a/vite-plugin-package-extension.js
+++ b/vite-plugin-package-extension.js
@@ -20,7 +20,7 @@ const distPathFirefox = `${distPathTemp}-firefox`;
  * @param {(object) => void} update Function to update the JSON object.
  */
 const updateJSON = async (filePath, update) => {
-  const obj = JSON.parse(await readFile(filePath));
+  const obj = JSON.parse(await readFile(filePath, 'utf-8'));
 
   update(obj);
   await writeFile(filePath, JSON.stringify(obj, null, 2));
@@ -99,6 +99,13 @@ export default function packageExtension() {
       async: true,
       sequential: true,
       handler: async () => {
+        if ((await readFile(`${distPathTemp}/scripts/sodium.js`, 'utf-8')).includes('innerHTML')) {
+          throw new Error(
+            `sodium.js contains innerHTML, which may cause a problem on YouTube due to CSP ` +
+              `require-trusted-types-for 'script'.`,
+          );
+        }
+
         console.log('Packaging started.');
 
         await updateJSON(`${distPathTemp}/manifest.json`, (obj) => {


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1084
Work around https://github.com/sveltejs/svelte/issues/10826

Svelte が `innerHTML` を出力しないようにコードを微調整します。他に `innerHTML` が使われているところは今のところ見当たりませんが、今後同じ問題が起きないようにビルド時のチェックも追加します。