### PR TITLE
ABEMA でオーバーレイ表示が一部隠れる問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -398,7 +398,7 @@ Config.ui.lemino = {
 
 // ABEMA
 Config.ui.abematv = {
-  target: `.com-tv-TVScreen__player-container, .com-vod-VODScreen-container`,
+  target: `.c-tv-NowOnAirContainer .com-tv-TVScreen, .com-vod-VODScreen-container`,
   style: `
   #${Config.ui.id} {
     position: absolute;
@@ -411,8 +411,15 @@ Config.ui.abematv = {
     z-index: 11;
     left: 65px;
   }
+  .c-tv-NowOnAirContainer .com-tv-TVScreen #${Config.ui.id} {
+    top: 76px;
+    left: 72px;
+  }
+  .c-tv-NowOnAirContainer__news-container--sidenav-expanded ~ .com-tv-TVScreen #${Config.ui.id} {
+    left: 196px;
+  }
   @media (any-pointer: fine) {
-    :is(.com-tv-TVScreen__player-container, .com-vod-VODScreen-container):not(:hover) > #${Config.ui.id} {
+    :is(.com-tv-TVScreen, .com-vod-VODScreen-container):not(:hover) > #${Config.ui.id} {
       opacity: 0;
     }
   }`,


### PR DESCRIPTION
Fix #298

生放送のページでは、マウスホバーによって上部の黒いヘッダーと左側のナビゲーションの表示・非表示が切り替わるようになっていて、表示中だとウィンドウサイズによってはオーバーレイが隠れてしまうことがあります。オーバーレイの挿入ターゲットを変えることで問題を回避します。VOD には影響ありません。

<img width="601" alt="Screenshot 2025-01-07 at 5 19 22 PM" src="https://github.com/user-attachments/assets/23e06c5b-4924-4208-9ec8-625667424c86" />