### PR TITLE
FOD の計測問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -353,6 +353,12 @@ Config.ui.tver = {
 Config.ui.fod = {
   ...Config.ui.general,
   target: '#fod_player, #video_container',
+  // 左上動画タイトルと被るので右上に表示
+  style: `#${Config.ui.id} {
+    position: absolute;
+    inset: 12px 12px auto auto;
+    z-index: 1000001;
+  }`,
 };
 
 // ニコニコ動画ではコメントより前面になるよう配置

--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -358,6 +358,13 @@ Config.ui.fod = {
     position: absolute;
     inset: 12px 12px auto auto;
     z-index: 1000001;
+    transition: 200ms;
+  }
+  @media (any-pointer: fine) {
+    #fod_player:not(:hover) #${Config.ui.id},
+    #video_container:not(:hover) #${Config.ui.id} {
+      opacity: 0;
+    }
   }`,
 };
 


### PR DESCRIPTION
Fix #305
Fix #309

- オーバーレイが動画左上に表示されるタイトルと被るので右上に移動
- オーバーレイを動画マウスホバー時のみ表示するよう変更
- 広告と本編動画の判定基準を現行サイトに合わせて修正
- タイトルとサムネイルの取得方法も併せて変更