### PR TITLE
Lemino の計測問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -382,15 +382,15 @@ Config.ui.nhkondemand = {
 // Lemino
 Config.ui.lemino = {
   target: `.fullscreen`,
+  // 左上動画タイトルと被るので右上に表示
   style: `#${Config.ui.id} {
   position: absolute;
   z-index: 1000001;
-  top: 12px;
-  left: 12px;
+  inset: 12px 60px auto auto;
   transition: 200ms;
 }
 @media (any-pointer: fine) {
-  #${Config.ui.id}:not(:hover){
+  .fullscreen:not(:hover) #${Config.ui.id} {
     opacity: 0;
   }
 }`,

--- a/src/lib/content/sodium/modules/LeminoTypeHandler.js
+++ b/src/lib/content/sodium/modules/LeminoTypeHandler.js
@@ -2,26 +2,25 @@ import GeneralTypeHandler from './GeneralTypeHandler';
 
 export default class LeminoTypeHandler extends GeneralTypeHandler {
   get_video_title() {
-    try {
-      return document.querySelector('.titleDetailHeading_title').textContent;
-    } catch (e) {
-      return '';
-    }
-  }
-
-  get_video_thumbnail() {
-    try {
-      return document.querySelector('.is-active .libertyBtn_image img').src;
-    } catch (e) {
-      return '';
-    }
+    return (
+      document
+        .querySelector('[class^="ContentsDetailPlayerIntro__TitleStyle"]')
+        ?.innerText.split(/\n+/)
+        .reverse()
+        .join(' – ') || null
+    );
   }
 
   is_main_video(video) {
-    return video === this.elm;
+    return (
+      video ===
+      /** @type {HTMLVideoElement} */ (document.querySelector('video:not([title="Advertisement"])'))
+    );
   }
 
   is_cm() {
-    return false;
+    return /** @type {HTMLVideoElement[]} */ ([
+      ...document.querySelectorAll('video[title="Advertisement"]'),
+    ]).some((video) => !!video.videoHeight);
   }
 }


### PR DESCRIPTION
Fix #306
Fix #308 

- オーバーレイが動画左上に表示されるタイトルと被るので右上に移動
- オーバーレイを動画マウスホバー時に表示するよう変更
- 広告と本編動画の判定基準を現行サイトに合わせて修正
- タイトルとサムネイルの取得方法も併せて変更 (サムネイルは通常の `og:image` で取得可能)
