### PR TITLE
ニコニコでオーバーレイを開くと動画が止まる問題を修正

### DIFF
--- a/src/lib/components/stats/stats-expander.svelte
+++ b/src/lib/components/stats/stats-expander.svelte
@@ -51,7 +51,7 @@
   role="button"
   tabindex="0"
   class="root"
-  on:pointerdown|preventDefault|stopPropagation={() => {
+  on:click|preventDefault|stopPropagation={() => {
     open = !open;
   }}
   on:keydown|preventDefault|stopPropagation={(event) => {


### PR DESCRIPTION
Fix #312

`pointerdown` では `event.stopPropagation()` が効かないようなので、`click` イベントに差し替えて、動画自体がクリックされないようにします。