### PR TITLE
検索結果の QoE 値表示に関する一連のバグを修正

### DIFF
--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -175,7 +175,7 @@ const getStorageKey = async (viewingId) => {
   }
 
   const keys = (await historyRecordsDB.keys()) ?? [];
-  const key = !keys.length ? 0 : keys.sort((a, b) => a - b).pop() + 1;
+  const key = !keys.length ? 0 : keys.sort((a, b) => Number(a) - Number(b)).pop() + 1;
 
   state[viewingId] = key;
 

--- a/src/lib/locales/en.js
+++ b/src/lib/locales/en.js
@@ -153,9 +153,10 @@ export const strings = {
           buttonLabel: 'Quality',
           dropdownLabel: 'QoE Value Range and Statuses',
           status: {
-            progress: 'Calculating',
+            pending: 'Calculating',
             complete: 'Calculated',
             error: 'Error',
+            unavailable: 'Unavailable',
           },
           input: {
             min: 'Min.',
@@ -202,6 +203,7 @@ export const strings = {
     transferSize: 'Transfer Size',
     dataMissing: 'Data unavailable',
     quality: {
+      unavailable: 'QoE rating is not available for this video platform.',
       measuringShort: 'Measuring...',
       measuring: 'QoE value is being measured or calculated.',
       provisional: 'This is a provisional QoE value. The final value is being calculated.',

--- a/src/lib/locales/en.js
+++ b/src/lib/locales/en.js
@@ -206,8 +206,8 @@ export const strings = {
       measuring: 'QoE value is being measured or calculated.',
       provisional: 'This is a provisional QoE value. The final value is being calculated.',
       error: 'We could not retrieve QoE values due to the lack of measurement data.',
-      frameDrops: 'Actual quality of experience may differ due to frame drops',
-      frameDropsShort: 'Actual quality of experience  may differ',
+      frameDrops: 'Actual quality of experience may differ due to frame drops.',
+      frameDropsShort: 'Actual quality of experience  may differ.',
     },
   },
   settings: {

--- a/src/lib/locales/en.js
+++ b/src/lib/locales/en.js
@@ -207,7 +207,7 @@ export const strings = {
       measuringShort: 'Measuring...',
       measuring: 'QoE value is being measured or calculated.',
       provisional: 'This is a provisional QoE value. The final value is being calculated.',
-      error: 'We could not retrieve QoE values due to the lack of measurement data.',
+      error: 'QoE value could not be retrieved due to missing measurement data or other reasons.',
       frameDrops: 'Actual quality of experience may differ due to frame drops.',
       frameDropsShort: 'Actual quality of experience  may differ.',
     },

--- a/src/lib/locales/en.js
+++ b/src/lib/locales/en.js
@@ -204,6 +204,7 @@ export const strings = {
     quality: {
       measuringShort: 'Measuring...',
       measuring: 'QoE value is being measured or calculated.',
+      provisional: 'This is a provisional QoE value. The final value is being calculated.',
       error: 'We could not retrieve QoE values due to the lack of measurement data.',
       frameDrops: 'Actual quality of experience may differ due to frame drops',
       frameDropsShort: 'Actual quality of experience  may differ',

--- a/src/lib/locales/ja.js
+++ b/src/lib/locales/ja.js
@@ -153,9 +153,10 @@ export const strings = {
           buttonLabel: '品質',
           dropdownLabel: 'QoE 値の範囲とステータス',
           status: {
-            progress: '計算中',
+            pending: '計算中',
             complete: '計算済み',
             error: 'エラー',
+            unavailable: '非対応',
           },
           input: {
             min: '最小値',
@@ -202,6 +203,7 @@ export const strings = {
     transferSize: '通信量',
     dataMissing: 'データ不足',
     quality: {
+      unavailable: 'この動画サービスは QoE 評価に対応していません。',
       measuringShort: '計測中...',
       measuring: 'QoE 値を計測または計算中です。',
       provisional: 'これは暫定 QoE 値です。確定値は計算中です。',

--- a/src/lib/locales/ja.js
+++ b/src/lib/locales/ja.js
@@ -207,7 +207,7 @@ export const strings = {
       measuringShort: '計測中...',
       measuring: 'QoE 値を計測または計算中です。',
       provisional: 'これは暫定 QoE 値です。確定値は計算中です。',
-      error: '計測データ不足のため QoE 値が得られませんでした。',
+      error: '計測データ不足あるいはその他の理由により QoE 値を取得できませんでした。',
       frameDrops: 'フレームドロップが発生したため実際の体感品質とは異なる可能性があります。',
       frameDropsShort: '実際の体感品質とは異なる可能性があります。',
     },

--- a/src/lib/locales/ja.js
+++ b/src/lib/locales/ja.js
@@ -203,10 +203,11 @@ export const strings = {
     dataMissing: 'データ不足',
     quality: {
       measuringShort: '計測中...',
-      measuring: 'QoE 値を計測または計算中です',
-      error: '計測データ不足のため QoE 値が得られませんでした',
-      frameDrops: 'フレームドロップが発生したため実際の体感品質とは異なる可能性があります',
-      frameDropsShort: '実際の体感品質とは異なる可能性があります',
+      measuring: 'QoE 値を計測または計算中です。',
+      provisional: 'これは暫定 QoE 値です。確定値は計算中です。',
+      error: '計測データ不足のため QoE 値が得られませんでした。',
+      frameDrops: 'フレームドロップが発生したため実際の体感品質とは異なる可能性があります。',
+      frameDropsShort: '実際の体感品質とは異なる可能性があります。',
     },
   },
   settings: {

--- a/src/lib/pages/history/detail-panel.svelte
+++ b/src/lib/pages/history/detail-panel.svelte
@@ -85,7 +85,7 @@
           {/if}
         </div>
         {#each historyItems as item (item.key)}
-          {@const { key, region = {}, startTime, stats } = item}
+          {@const { key, region = {}, startTime, calculable, stats } = item}
           {@const { provisionalQoe, finalQoe, isLowQuality } = stats}
           {@const { country, subdivision } = region ?? {}}
           {@const formattedStats = formatStats($locale, stats)}
@@ -121,7 +121,9 @@
                     </Button>
                   </h4>
                   <div>
-                    {#if finalQoe === undefined || finalQoe === -1}
+                    {#if !calculable}
+                      {$_('stats.quality.unavailable')}
+                    {:else if finalQoe === undefined || finalQoe === -1}
                       {#if Number.isFinite(provisionalQoe)}
                         <QualityBar value={provisionalQoe} />
                         <Alert

--- a/src/lib/pages/history/detail-panel.svelte
+++ b/src/lib/pages/history/detail-panel.svelte
@@ -19,8 +19,6 @@
   /** @type {HistoryItem[]} */
   export let historyItems = [];
 
-  $: console.info({ historyItems });
-
   const { SODIUM_MARKETING_SITE_URL } = import.meta.env;
 
   const completeHistory = () => {

--- a/src/lib/pages/history/detail-panel.svelte
+++ b/src/lib/pages/history/detail-panel.svelte
@@ -85,8 +85,8 @@
           {/if}
         </div>
         {#each historyItems as item (item.key)}
-          {@const { key, region = {}, startTime, calculable, stats } = item}
-          {@const { provisionalQoe, finalQoe, isLowQuality } = stats}
+          {@const { key, region = {}, startTime, stats } = item}
+          {@const { calculable, provisionalQoe, finalQoe, isLowQuality } = stats}
           {@const { country, subdivision } = region ?? {}}
           {@const formattedStats = formatStats($locale, stats)}
           {@const deleted = $deletedHistoryItemKeys.includes(key)}

--- a/src/lib/pages/history/history-item.svelte
+++ b/src/lib/pages/history/history-item.svelte
@@ -23,7 +23,7 @@
    */
   let itemWrapper;
 
-  $: ({ key, platform, url, title, thumbnail, startTime, stats } = historyItem);
+  $: ({ key, platform, url, title, thumbnail, startTime, calculable, stats } = historyItem);
   $: ({ provisionalQoe, finalQoe, isLowQuality } = stats);
 
   const playAgain = () => {
@@ -116,7 +116,9 @@
         {formatDateTime(startTime)}
       </div>
       <div class="qoe">
-        {#if finalQoe === undefined || finalQoe === -1}
+        {#if !calculable}
+          <!--  -->
+        {:else if finalQoe === undefined || finalQoe === -1}
           <Icon name="hourglass_empty" aria-label={$_('stats.quality.measuring')} />
           {#if Number.isFinite(provisionalQoe)}
             {provisionalQoe.toFixed(2)}

--- a/src/lib/pages/history/history-item.svelte
+++ b/src/lib/pages/history/history-item.svelte
@@ -23,8 +23,8 @@
    */
   let itemWrapper;
 
-  $: ({ key, platform, url, title, thumbnail, startTime, calculable, stats } = historyItem);
-  $: ({ provisionalQoe, finalQoe, isLowQuality } = stats);
+  $: ({ key, platform, url, title, thumbnail, startTime, stats } = historyItem);
+  $: ({ calculable, provisionalQoe, finalQoe, isLowQuality } = stats);
 
   const playAgain = () => {
     if (!platform?.deprecated) {

--- a/src/lib/pages/history/history-item.svelte
+++ b/src/lib/pages/history/history-item.svelte
@@ -8,6 +8,7 @@
   import { goto, openTab } from '$lib/services/navigation';
   import { settings } from '$lib/services/settings';
 
+  /** @type {HistoryItem} */
   export let historyItem = {};
   export let horizontal = false;
 
@@ -22,8 +23,8 @@
    */
   let itemWrapper;
 
-  $: ({ key, platform, url, title, thumbnail, startTime, stats } = historyItem || {});
-  $: ({ qoe, isLowQuality } = stats);
+  $: ({ key, platform, url, title, thumbnail, startTime, stats } = historyItem);
+  $: ({ provisionalQoe, finalQoe, isLowQuality } = stats);
 
   const playAgain = () => {
     if (!platform?.deprecated) {
@@ -115,9 +116,12 @@
         {formatDateTime(startTime)}
       </div>
       <div class="qoe">
-        {#if qoe === undefined || qoe === -1}
+        {#if finalQoe === undefined || finalQoe === -1}
           <Icon name="hourglass_empty" aria-label={$_('stats.quality.measuring')} />
-        {:else if qoe === -2}
+          {#if Number.isFinite(provisionalQoe)}
+            {provisionalQoe.toFixed(2)}
+          {/if}
+        {:else if finalQoe === -2}
           <Icon name="error" aria-label={$_('stats.quality.error')} />
         {:else}
           {#if isLowQuality}
@@ -125,7 +129,7 @@
           {:else}
             <Icon name="equalizer" />
           {/if}
-          {qoe.toFixed(2)}
+          {finalQoe.toFixed(2)}
         {/if}
       </div>
       <div class="actions close-popup">

--- a/src/lib/pages/routes/history.svelte
+++ b/src/lib/pages/routes/history.svelte
@@ -9,6 +9,7 @@
   import OnboardingWrapper from '$lib/pages/onboarding/onboarding-wrapper.svelte';
   import { viewingHistory } from '$lib/services/history';
 
+  /** @type {HistoryItem[]} */
   let historyItems = [];
   let showDialog = false;
 

--- a/src/lib/services/api.js
+++ b/src/lib/services/api.js
@@ -67,7 +67,7 @@ export const fetchViewerRegion = async (videoId, sessionId) => {
 };
 
 /**
- * 与えられた ID リストに該当する動画の最終 QoE 値を取得。
+ * 与えられた ID リストに該当する動画の確定 QoE 値を取得。
  * @param {{ videoId: string, sessionId: string }[]} ids 動画再生・セッション ID のリスト。
  * @returns {Promise.<object[]>} 結果。
  */

--- a/src/lib/services/history/index.js
+++ b/src/lib/services/history/index.js
@@ -9,20 +9,30 @@ const maxItems = 10000;
 
 /**
  * 有効な計測・計算ステータスのリスト。
+ * @type {QualityStatus}
  */
-export const validQualityStatuses = ['progress', 'complete', 'error'];
+export const validQualityStatuses = ['pending', 'complete', 'error', 'unavailable'];
 
 /**
  * QoE 値から計測・計算ステータスを取得する。
- * @param {(number | undefined)} qoe QuE 値。
- * @returns {('progress' | 'complete' | 'error')} ステータス。
+ * @param {HistoryItem} historyItem 履歴アイテム。
+ * @returns {QualityStatus} ステータス。
  */
-export const getQualityStatus = (qoe) => {
-  if (qoe === undefined || qoe === -1) {
-    return 'progress';
+export const getQualityStatus = (historyItem) => {
+  const {
+    calculable,
+    stats: { finalQoe },
+  } = historyItem;
+
+  if (!calculable) {
+    return 'unavailable';
   }
 
-  if (qoe === -2) {
+  if (finalQoe === undefined || finalQoe === -1) {
+    return 'pending';
+  }
+
+  if (finalQoe === -2) {
     return 'error';
   }
 
@@ -212,7 +222,7 @@ export const searchResults = derived([searchCriteria, viewingHistory], (states) 
 
     const { country = '', subdivision = '' } = region ?? {};
     const hasRegion = !!(country && subdivision);
-    const qualityStatus = getQualityStatus(finalQoe);
+    const qualityStatus = getQualityStatus(historyItem);
     const date = new Date(startTime);
 
     return (

--- a/src/lib/services/history/index.js
+++ b/src/lib/services/history/index.js
@@ -105,7 +105,7 @@ export const completeViewingHistoryItem = async (historyItem) => {
     stats: { finalQoe },
   } = historyItem;
 
-  const { logs, transferSize } = await historyStatsDB.get(key);
+  const { logs = [], transferSize = 0 } = (await historyStatsDB.get(key)) ?? {};
 
   /** @type {number[]} */
   const throughputList = logs

--- a/src/lib/services/stats.js
+++ b/src/lib/services/stats.js
@@ -109,7 +109,7 @@ export const formatStats = (locale, details) => {
     creationDate,
     startTime,
     timing: { waiting, pause } = {},
-    qoe,
+    finalQoE,
   } = details;
 
   const dropRate =
@@ -139,6 +139,6 @@ export const formatStats = (locale, details) => {
       ? `${formatFloat(locale, waiting / 1e3)} / ${formatSec(locale, playing / 1e3)}
         (${formatPercent(locale, waitingRate)})`
       : null,
-    qoe: isValidNumber(qoe) ? qoe.toFixed(2) : null,
+    qoe: isValidNumber(finalQoE) ? finalQoE.toFixed(2) : null,
   };
 };

--- a/src/lib/services/video-platforms.js
+++ b/src/lib/services/video-platforms.js
@@ -1,19 +1,4 @@
 /**
- * 動画プラットフォームのプロパティ。
- * @typedef {object} VideoPlatform
- * @property {string} id 固有の ID。
- * @property {string} url サービス URL。
- * @property {string} brandColor ブランドカラー。
- * @property {string[]} hosts サービスのホスト名リスト。`manifest.json` や `request_rules.json` など複数
- * 箇所で利用され、自動的に正規表現やドメインのみの表記に変換されます。サブドメインが複数ある場合はワイルドカードを使う
- * ことも可能。例えば `*.youtube.com` は `youtube.com` とそのサブドメインすべてに一致します。
- * @property {RegExp[]} hostREs 正規表現で表したサービスのホスト名リスト。`hosts` のワイルドカード表記より細かい
- * 設定が可能。指定されていない場合は `hosts` を自動的に正規表現に変換して使用。
- * @property {boolean} [deprecated] 廃止されたサービスは `true`。
- * @property {boolean} [experimental] 試験的に対応しているサービスは `true`。
- */
-
-/**
  * ホスト名パターンを正規表現に変換。正規表現用のエスケープを適用した後、さらにワイルドカード部分を変換。
  * @param {string} origin ホスト名パターン。`*.youtube.com` のようにワイルドカードを含めることも可能。
  * @returns {RegExp} 正規表現。

--- a/src/lib/typedefs.js
+++ b/src/lib/typedefs.js
@@ -1,0 +1,43 @@
+/**
+ * 動画プラットフォームのプロパティ。
+ * @typedef {object} VideoPlatform
+ * @property {string} id 固有の ID。
+ * @property {string} url サービス URL。
+ * @property {string} brandColor ブランドカラー。
+ * @property {string[]} hosts サービスのホスト名リスト。`manifest.json` や `request_rules.json` など複数
+ * 箇所で利用され、自動的に正規表現やドメインのみの表記に変換される。サブドメインが複数ある場合はワイルドカードを使うこ
+ * とも可能。例えば `*.youtube.com` は `youtube.com` とそのサブドメインすべてに一致する。
+ * @property {RegExp[]} hostREs 正規表現で表したサービスのホスト名リスト。`hosts` のワイルドカード表記より細かい
+ * 設定が可能。指定されていない場合は `hosts` を自動的に正規表現に変換して使用。
+ * @property {boolean} [deprecated] 廃止されたサービスは `true`。
+ * @property {boolean} [experimental] 試験的に対応しているサービスは `true`。
+ */
+
+/**
+ * 視聴履歴アイテム。
+ * @typedef {object} HistoryItem
+ * @property {number} key IndexedDB レコードのキー。
+ * @property {string} playbackId プレーバック UUID。再生するたびに異なる。
+ * @property {string} sessionId セッション UUID.
+ * @property {string} viewingId プレーバック UUID とセッション UUID をアンダースコアで結合したもの。
+ * @property {VideoPlatform} platform 動画プラットフォームの詳細。
+ * @property {string} title 動画タイトル。
+ * @property {string} url プラットフォーム上の動画再生ページの URL.
+ * @property {string | undefined} thumbnail 動画サムネイル URL。
+ * @property {number} startTime 再生開始時刻のタイムスタンプ。
+ * @property {object | undefined} region 視聴地域。
+ * @property {string} region.country 国コード。
+ * @property {string} region.subdivision 日本の都道府県あるいは各国の州コード。
+ * @property {boolean} calculable 当該プラットフォームにおいて QoE 値を計算可能かどうか。
+ * @property {HistoryItemStats} stats 統計情報。
+ */
+
+/**
+ * 視聴履歴アイテムの統計情報。
+ * @typedef {object} HistoryItemStats
+ * @property {number | undefined} provisionalQoe 暫定 QoE 値。
+ * @property {number | undefined} finalQoe 確定 QoE 値。
+ * @property {number} throughput スループット。
+ * @property {number} transferSize 転送データ量。
+ * @property {boolean} isLowQuality QoE が低品質かどうか。
+ */

--- a/src/lib/typedefs.js
+++ b/src/lib/typedefs.js
@@ -28,13 +28,13 @@
  * @property {object | undefined} region 視聴地域。
  * @property {string} region.country 国コード。
  * @property {string} region.subdivision 日本の都道府県あるいは各国の州コード。
- * @property {boolean} calculable 当該プラットフォームにおいて QoE 値を計算可能かどうか。
  * @property {HistoryItemStats} stats 統計情報。
  */
 
 /**
  * 視聴履歴アイテムの統計情報。
  * @typedef {object} HistoryItemStats
+ * @property {boolean} calculable 当該プラットフォームにおいて QoE 値を計算可能かどうか。
  * @property {number | undefined} provisionalQoe 暫定 QoE 値。
  * @property {number | undefined} finalQoe 確定 QoE 値。通常は正の値だが、`-1` は計算未完了、`-2` は何らかの
  * 理由による取得エラーを表す。

--- a/src/lib/typedefs.js
+++ b/src/lib/typedefs.js
@@ -36,7 +36,8 @@
  * 視聴履歴アイテムの統計情報。
  * @typedef {object} HistoryItemStats
  * @property {number | undefined} provisionalQoe 暫定 QoE 値。
- * @property {number | undefined} finalQoe 確定 QoE 値。
+ * @property {number | undefined} finalQoe 確定 QoE 値。通常は正の値だが、`-1` は計算未完了、`-2` は何らかの
+ * 理由による取得エラーを表す。
  * @property {number} throughput スループット。
  * @property {number} transferSize 転送データ量。
  * @property {boolean} isLowQuality QoE が低品質かどうか。

--- a/src/lib/typedefs.js
+++ b/src/lib/typedefs.js
@@ -41,3 +41,8 @@
  * @property {number} transferSize 転送データ量。
  * @property {boolean} isLowQuality QoE が低品質かどうか。
  */
+
+/**
+ * 視聴履歴アイテムの最終 QoE 値取得状況。
+ * @typedef {'pending' | 'complete' | 'error' | 'unavailable'} QualityStatus
+ */


### PR DESCRIPTION
Fix #314

検索結果の一覧と詳細パネルでは、確定 QoE 値の計算が終わっていない場合、暫定 QoE 値が取得できていればその数値を表示していますが、計算が完了しているように見えてしまうので、表記を変更します。

### 一覧

アイコンを砂時計に変更

<img width="271" alt="image" src="https://github.com/user-attachments/assets/276d6f3b-791c-4d6b-b979-032937da284c" />

### 詳細

表示している数字が暫定値で、確定値は計算中であることを明記

<img width="562" alt="image" src="https://github.com/user-attachments/assets/a977cdff-caee-417a-a53c-66c0ee16e915" />

### その他の修正

- 確定 QoE 値を取得できているのに検索結果の UI も内部データベースも更新されていない問題を修正 (レコードキーの参照が number ではなく string で行われていたため)
- 1 時間以上確定 QoE 値が得られなかった場合はタイムアウトとし、エラーとして保存する
- ニコニコや FOD など QoE 計算に対応していないプラットフォームで QoE 値が永遠に計算中と表示される問題を修正 (非対応プラットフォームでは非対応と表示)