### PR TITLE
動画サムネイルのフォールバックを設定

### DIFF
--- a/src/lib/pages/history/detail-panel.svelte
+++ b/src/lib/pages/history/detail-panel.svelte
@@ -2,6 +2,7 @@
   import { Alert, Button, Drawer, Group, Icon } from '@sveltia/ui';
   import { _, locale } from 'svelte-i18n';
   import QualityBar from '$lib/pages/history/quality-bar.svelte';
+  import VideoThumbnail from '$lib/pages/history/video-thumbnail.svelte';
   import { getHourlyQoe, getRegionalQoe } from '$lib/services/aggregations';
   import {
     completeViewingHistoryItem,
@@ -52,15 +53,15 @@
       <header>
         <div class="thumbnail">
           {#if platform?.deprecated}
-            <img src={thumbnail} alt="" />
+            <VideoThumbnail src={thumbnail} />
             <div class="overlay">
               <Alert status="error" aria-live="off" --font-size="var(--sui-font-size-small)">
                 {$_('history.detail.platformDeprecated')}
               </Alert>
             </div>
           {:else}
-            <a href={url} target="_blank">
-              <img src={thumbnail} alt={$_('history.detail.playAgain')} />
+            <a href={url} target="_blank" title={$_('history.detail.playAgain')}>
+              <VideoThumbnail src={thumbnail} />
             </a>
           {/if}
         </div>
@@ -250,13 +251,8 @@
         display: block;
       }
 
-      img {
-        display: block;
-        width: 100%;
+      :global(.thumbnail) {
         border-radius: 4px;
-        aspect-ratio: 16 / 9;
-        object-fit: cover;
-        background-color: var(--video-background-color);
       }
     }
 

--- a/src/lib/pages/history/detail-panel.svelte
+++ b/src/lib/pages/history/detail-panel.svelte
@@ -60,7 +60,7 @@
               </Alert>
             </div>
           {:else}
-            <a href={url} target="_blank" title={$_('history.detail.playAgain')}>
+            <a href={url} target="_blank" aria-label={$_('history.detail.playAgain')}>
               <VideoThumbnail src={thumbnail} />
             </a>
           {/if}

--- a/src/lib/pages/history/history-item.svelte
+++ b/src/lib/pages/history/history-item.svelte
@@ -3,6 +3,7 @@
   import { waitForVisibility } from '@sveltia/utils/element';
   import { onMount } from 'svelte';
   import { _ } from 'svelte-i18n';
+  import VideoThumbnail from '$lib/pages/history/video-thumbnail.svelte';
   import { completeViewingHistoryItem, viewingHistory } from '$lib/services/history';
   import { formatDateTime } from '$lib/services/i18n';
   import { goto, openTab } from '$lib/services/navigation';
@@ -70,7 +71,7 @@
     }}
   >
     <div class="hero">
-      <img loading="lazy" class="thumbnail" src={thumbnail} alt="" />
+      <VideoThumbnail src={thumbnail} />
     </div>
     <div class="actions close-popup">
       {#if platform?.deprecated}
@@ -186,14 +187,6 @@
     position: relative;
     overflow: hidden;
     aspect-ratio: 16 / 9;
-
-    .thumbnail {
-      width: 100%;
-      aspect-ratio: 16 / 9;
-      object-fit: cover;
-      background-color: var(--sui-video-background-color);
-      transition: all 0.5s;
-    }
   }
 
   .body {
@@ -249,7 +242,7 @@
     .item {
       &:hover,
       &:active {
-        .primary .thumbnail {
+        .primary :global(.thumbnail) {
           transform: scale(110%);
         }
       }

--- a/src/lib/pages/history/video-thumbnail.svelte
+++ b/src/lib/pages/history/video-thumbnail.svelte
@@ -1,0 +1,44 @@
+<script>
+  /** @type {string | undefined} */
+  export let src;
+</script>
+
+{#if src}
+  <img
+    loading="lazy"
+    {src}
+    alt=""
+    class="thumbnail"
+    on:error={() => {
+      src = '';
+    }}
+  />
+{:else}
+  <div class="thumbnail fallback"></div>
+{/if}
+
+<style lang="scss">
+  .thumbnail {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    background-color: var(--video-background-color);
+    transition: all 0.5s;
+  }
+
+  .fallback {
+    position: relative;
+
+    &::after {
+      position: absolute;
+      inset: 0;
+      background-image: url(/images/logo.svg);
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: 40%;
+      filter: grayscale(1) opacity(0.1);
+      content: '';
+    }
+  }
+</style>


### PR DESCRIPTION
Fix #317

サムネイルが取得できなかった、削除された、あるいはオフライン時に表示できない場合、現状壊れた画像が表示されてしまっているので、VideoMark のロゴをフォールバックとして表示します。

<img width="269" alt="image" src="https://github.com/user-attachments/assets/4715bf89-4c3f-484e-adde-c5684f34680e" />
