### PR TITLE
検索条件の意図せぬリセットを防止

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@sveltia/ui": "^0.15.16",
     "@sveltia/utils": "^0.6.3",
     "@videomark/sparkline": "github:videomark/sparkline",
+    "fast-equals": "^5.2.2",
     "m3u8-parser": "^7.2.0",
     "msgpack-lite": "^0.1.26",
     "uuid": "^11.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@videomark/sparkline':
         specifier: github:videomark/sparkline
         version: https://codeload.github.com/videomark/sparkline/tar.gz/da263f1f1429787c606fe5885c9b85518472f4c2
+      fast-equals:
+        specifier: ^5.2.2
+        version: 5.2.2
       m3u8-parser:
         specifier: ^7.2.0
         version: 7.2.0


### PR DESCRIPTION
Fix #320
Fix #322

検索結果に出てくる個々の履歴は、当初は必要最低限の情報だけ読み出しておいて、ページ上のビューポートに入ってから [`completeViewingHistoryItem()`](https://github.com/videomark/videomark/blob/99166adc89bc01e5ed75b30f384e42d97d0e03f7/src/lib/services/history/index.js#L111) で情報を追加するというパフォーマンス処理を行っていますが、これが意図せぬ検索条件のリセットにつながっていました。条件判定を加えてこの問題を回避します。