### PR TITLE
ABEMA のミニプレーヤーではオーバーレイを非表示に

### DIFF
--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -431,6 +431,10 @@ Config.ui.abematv = {
   .c-tv-NowOnAirContainer__news-container--sidenav-expanded ~ .com-tv-TVScreen #${Config.ui.id} {
     left: 196px;
   }
+  /* ミニプレーヤー内ではオーバーレイが見切れるので非表示に */
+  .com-vod-VODMiniPlayerWrapper__player--mini #${Config.ui.id} {
+    display: none;
+  }
   @media (any-pointer: fine) {
     :is(.com-tv-TVScreen, .com-vod-VODScreen-container):not(:hover) > #${Config.ui.id} {
       opacity: 0;


### PR DESCRIPTION
Fix #328

オンデマンドの動画を再生中にスクロールダウンすると、動画が画面右下のミニプレーヤーへ移動しますが、領域が狭すぎてオーバーレイを表示しきれません。このため非表示にしてしまいます。