### PR TITLE
ABEMA チャンネルに対応

### DIFF
--- a/src/lib/content/sodium/modules/AbemaTVVideoTypeHandler.js
+++ b/src/lib/content/sodium/modules/AbemaTVVideoTypeHandler.js
@@ -12,7 +12,7 @@ export default class AbemaTVVideoTypeHandler extends GeneralTypeHandler {
       throw new Error('video is not main');
     }
 
-    const target = document.querySelector('.c-vod-EpisodePlayerContainer-screen');
+    const target = document.querySelector('.com-vod-VODScreen-container');
 
     this.adObserver = new AdObserver(this, target);
   }

--- a/src/lib/content/sodium/modules/VideoHandler.js
+++ b/src/lib/content/sodium/modules/VideoHandler.js
@@ -50,16 +50,18 @@ export default class VideoHandler {
       this.service = 'lemino';
       console.log('Lemino Type Handler');
     } else if (url.host === 'abema.tv') {
-      if (url.pathname.split('/').indexOf('video') >= 0) {
+      const { segment } = url.pathname.match(/^\/(?<segment>.+?)\//)?.groups ?? {};
+
+      if (segment === 'channels' || segment === 'video') {
         this.handler = new AbemaTVVideoTypeHandler(elm);
         this.service = 'abematv_video';
         console.log('Abema TV Video Type Handler');
-      } else if (url.pathname.split('/').some((name) => name === 'now-on-air')) {
+      } else if (segment === 'now-on-air') {
         this.handler = new AbemaTVLiveTypeHandler(elm);
         this.service = 'abematv_live';
         this.calQoeFlg = true;
         console.log('Abema TV Live Type Handler');
-      } else if (url.pathname.split('/').some((name) => name === 'live-event')) {
+      } else if (segment === 'live-event') {
         this.handler = new AbemaTVLiveEventTypeHandler(elm);
         this.service = 'abematv_live_event';
         this.calQoeFlg = true;


### PR DESCRIPTION
Fix #327

`https://abema.tv/channels/` 以下の動画が計測対象となっていないので、対象に追加します。プレーヤーは通常の動画と同じ。`AdObserver` 向けの CSS クエリも両対応としました。