### PR TITLE
Netflix で映画の計測が始まらない問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/NetflixTypeHandler.js
+++ b/src/lib/content/sodium/modules/NetflixTypeHandler.js
@@ -5,7 +5,10 @@ class NetflixTypeHandler extends GeneralTypeHandler {
   /** @param {HTMLVideoElement} elm */
   constructor(elm) {
     super(elm);
-    this.elm = elm;
+
+    if (!this.is_main_video(elm)) {
+      throw new Error('video is not main');
+    }
   }
 
   /**
@@ -158,8 +161,8 @@ class NetflixTypeHandler extends GeneralTypeHandler {
     const metadata = this.#videoMetadata;
 
     return (
-      metadata.getEpisodeThumbnail()?.url ??
-      metadata.toVideoData().artwork[0]?.url ??
+      metadata._video.stills?.[0]?.url ??
+      metadata._video.artwork?.[0]?.url ??
       'https://assets.nflxext.com/en_us/pages/wiplayer/logo_v3.svg'
     );
   }


### PR DESCRIPTION
Fix #326

Netflix の内部 API (`getEpisodeThumbnail`) が例外を吐いているのが原因と分かったので、サムネイルの取得方法を変更しました。それから、インデックスページの予告編でも計測セッションが始まっていたので、他のサービスと同様にそれを回避するための `is_main_video` の判別を入れました。(`this.elm = elm` は `super` で呼び出されるため冗長なので削除)