### PR TITLE
Lemino で計測が始まらない場合がある問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/LeminoTypeHandler.js
+++ b/src/lib/content/sodium/modules/LeminoTypeHandler.js
@@ -12,10 +12,7 @@ export default class LeminoTypeHandler extends GeneralTypeHandler {
   }
 
   is_main_video(video) {
-    return (
-      video ===
-      /** @type {HTMLVideoElement} */ (document.querySelector('video:not([title="Advertisement"])'))
-    );
+    return video.matches('[src^="blob:"]:not([title="Advertisement"])');
   }
 
   is_cm() {


### PR DESCRIPTION
Fix https://github.com/videomark/videomark/issues/335

アニメに関しては再現条件が分からないのですが、[ニュース](https://lemino.docomo.ne.jp/news?newsTab=1)を自動で連続再生したときに計測が始まらない問題を確認したので、それを回避するようにしました。