### PR TITLE
Playwright テストがすべて失敗している問題を修正

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,9 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm exec playwright install --with-deps
+      # Opt-in to new headless
+      # https://github.com/microsoft/playwright/issues/33566
+      - run: pnpm exec playwright install --with-deps --no-shell
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: pnpm exec playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -16,7 +16,12 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        // Opt-in to new headless
+        // https://github.com/microsoft/playwright/issues/33566
+        channel: 'chromium',
+      },
     },
     {
       name: 'firefox',

--- a/tests/common.js
+++ b/tests/common.js
@@ -10,9 +10,10 @@ export const test = base.extend({
     const pathToExtension = new URL('../dist/production-chrome', import.meta.url).pathname;
 
     const context = await chromium.launchPersistentContext('', {
-      headless: true,
+      // Opt-in to new headless
+      // https://github.com/microsoft/playwright/issues/33566
+      channel: 'chromium',
       args: [
-        `--headless=new`,
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
       ],


### PR DESCRIPTION
Fix https://github.com/videomark/videomark/issues/316

Playwright v1.49 でヘッドレスの Chromium が更新されたのが原因でした。テストを新しいものに合わせます。

- https://github.com/microsoft/playwright/issues/33566

YouTube での暫定 QoE テストはタイムアウトで相変わらず失敗します。拡張機能ページ内のテストもランダムで失敗することがあり、原因はまだ確認できていませんが、少なくとも全部失敗することはなくなります。