### PR TITLE
コード分割によって設定が読み込まれない script URL の問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,6 @@
       "@parcel/watcher",
       "es5-ext"
     ]
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,5 @@
       "@parcel/watcher",
       "es5-ext"
     ]
-  },
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+  }
 }

--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -168,7 +168,7 @@ export default class Config {
 
     const browser_quota_value /* byte */ = browser_quota
       ? browser_quota /* MiB */ * 1024 * 1024
-      : Infinity;
+      : Number.POSITIVE_INFINITY;
 
     const browser_quota_full =
       control_by_browser_quota && browser_quota_value < (transfer_size[month] || 0);
@@ -524,7 +524,7 @@ Config.quality_control = false;
 
 const currentScript =
   typeof document === 'object' // Vitest 内で例外が投げられるのを回避するためのチェック
-    ? document.querySelector(`script[type="module"][src="${import.meta.url}"]`)
+    ? document.querySelector(`script[type="module"][src^="${new URL(import.meta.url).origin}/"]`)
     : null;
 
 if (currentScript !== null) {


### PR DESCRIPTION
Config.get_settings() が意図しない値が得られている問題を修正しました。
この変更によってプロダクションビルドで設定が反映され動画視聴中のオーバーレイ部分の設定が適切に反映されるようになります。
(YouTubeで表示されない問題は別の原因)
