### PR TITLE
YouTube で QoE 計測とオーバーレイ表示が機能していない問題を修正

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -37,6 +37,7 @@
       "js": [
         "scripts/content.js"
       ],
+      "run_at": "document_start",
       "all_frames": false
     }
   ],


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1182

- `Object.defineProperty` で `fetch` の書き換えが禁止されているので、これを実行しているスクリプトの挿入を検知して、実行前に削除してしまいます。
- `content.js` がページ内スクリプトより前に実行されるよう、タイミングを `document_start` に変更します。そうすると `<body>` が存在しないので、`sodium.js` の挿入先を `document.documentElement` に変更します。