### PR TITLE
計測オーバーレイの詳細に QoE の行が表示されてしまっている問題を修正

### DIFF
--- a/src/lib/components/stats/stats-body.svelte
+++ b/src/lib/components/stats/stats-body.svelte
@@ -44,7 +44,9 @@
     {/each}
   </colgroup>
   {#each Object.entries(formattedStats) as [prop, displayValue] (prop)}
-    <StatsRow {prop} label={$_(`stats.${prop}`)} {displayValue} chartData={[...log[prop]]} />
+    {#if prop !== 'qoe'}
+      <StatsRow {prop} label={$_(`stats.${prop}`)} {displayValue} chartData={[...log[prop]]} />
+    {/if}
   {/each}
 </table>
 


### PR DESCRIPTION
どこかの時点でオーバーレイの行に QoE 値が追加されてしまったので、これを削除します。

<img width="406" alt="Screenshot 2025-06-10 at 9 58 53 PM" src="https://github.com/user-attachments/assets/191b1413-40de-4e68-aac1-f3b7fb89f894" />