### PR TITLE
ポップアップから確実に統計データを開けるようにする

### DIFF
--- a/src/lib/services/navigation.js
+++ b/src/lib/services/navigation.js
@@ -1,3 +1,4 @@
+import { sleep } from '@sveltia/utils/misc';
 import { get, writable } from 'svelte/store';
 import { isMobile } from '$lib/services/runtime';
 
@@ -43,6 +44,15 @@ export const openTab = async (url) => {
   });
 
   if (currentTab) {
+    if (isInternalPage) {
+      // タブを再読み込み
+      // @todo リアルタイム更新を実装した場合は削除すること
+      await chrome.tabs.reload(currentTab.id);
+      // 再読み込みが完了するまで待機
+      await sleep(100);
+    }
+
+    // タブを切り替え
     await chrome.tabs.update(currentTab.id, {
       url: isInternalPage ? url : undefined, // `undefined` であればタブの URL は維持される
       active: true,


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1186

リアルタイム更新を実装するまでは「統計データを表示」ボタン押下時にタブを再読み込みするようにします。これで必ず再生中の動画が履歴ページに追加されて、統計データが表示されるようになります。