### PR TITLE
YouTube iframe 内の測定に対応

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -38,7 +38,7 @@
         "scripts/content.js"
       ],
       "run_at": "document_start",
-      "all_frames": false
+      "all_frames": true
     }
   ],
   "background": {

--- a/src/lib/content/sodium/modules/Config.spec.js
+++ b/src/lib/content/sodium/modules/Config.spec.js
@@ -3,6 +3,7 @@ import Config from '$lib/content/sodium/modules/Config';
 
 test('get_video_platform', () => {
   expect(Config.get_video_platform('www.youtube.com')).toBe('youtube');
+  expect(Config.get_video_platform('www.youtube-nocookie.com')).toBe('youtube');
   expect(Config.get_video_platform('m.youtube.com')).toBe('m_youtube_com');
   expect(Config.get_video_platform('www.netflix.com')).toBe('netflix');
   expect(Config.get_video_platform('tver.jp')).toBe('tver');

--- a/src/lib/services/video-platforms.js
+++ b/src/lib/services/video-platforms.js
@@ -18,7 +18,7 @@ export const videoPlatforms = [
     id: 'youtube',
     url: 'https://www.youtube.com/',
     brandColor: '#cc0000',
-    hosts: ['*.youtube.com'],
+    hosts: ['*.youtube.com', 'www.youtube-nocookie.com'],
   },
   {
     id: 'netflix',


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/14

#356 で埋め込みページには対応したので、あとは iframe への対応を追加するだけです。あちこちのサイトに散らばっている YouTube 動画をまとめて VideoMark の視聴履歴で見られるので、UX 的には大変便利です。

メモ:

- プライバシー強化モード用のホスト名 `www.youtube-nocookie.com` を追加
    - 例えば https://blog.google/ で使われている
- `isYouTubeVideoResource()` 内の `get_video_info` は使われていないようなので削除