### PR TITLE
YouTube チャンネルホームでの計測に対応

### DIFF
--- a/src/lib/components/stats/stats-body.svelte
+++ b/src/lib/components/stats/stats-body.svelte
@@ -1,7 +1,9 @@
 <script>
   import { Icon } from '@sveltia/ui';
+  import { onMount } from 'svelte';
   import { _, locale } from 'svelte-i18n';
   import StatsRow from '$lib/components/stats/stats-row.svelte';
+  import { YOUTUBE_PLAYER_SELECTOR } from '$lib/content/sodium/modules/Config';
   import { formatStats } from '$lib/services/stats';
 
   /**
@@ -25,14 +27,17 @@
    * 動画コーデックが H.264 以外 (VP8/VP9/AV1) かどうか。(YouTube のみ)
    * @type {boolean}
    */
-  const isNewerCodec = $derived.by(() => {
+  let isNewerCodec = $state(false);
+
+  onMount(() => {
     try {
-      const { codecs } = document.querySelector('#movie_player')?.getStatsForNerds() ?? {};
+      const player = document.querySelector(YOUTUBE_PLAYER_SELECTOR);
+      const { codecs } = player?.getStatsForNerds() ?? {};
       const isH264 = codecs?.startsWith('avc1.') ?? false;
 
-      return !isH264;
+      isNewerCodec = !isH264;
     } catch {
-      return false;
+      //
     }
   });
 </script>

--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -2,6 +2,12 @@ import { getDataFromContentJs } from '$lib/content/sodium/modules/Utils';
 import { videoPlatforms } from '$lib/services/video-platforms';
 
 /**
+ * YouTube 動画プレイヤーのクエリセレクター。
+ */
+export const YOUTUBE_PLAYER_SELECTOR =
+  '.ytd-page-manager:not([hidden]) .html5-video-player, #movie_player';
+
+/**
  * 動作設定
  */
 export default class Config {
@@ -317,7 +323,7 @@ Config.ui.m_youtube_com = {
 
 // YouTube
 Config.ui.youtube = {
-  target: '#movie_player',
+  target: YOUTUBE_PLAYER_SELECTOR,
   style: `#${Config.ui.id} {
   position: absolute;
   z-index: 1000001;

--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -6,6 +6,7 @@ import ResourceTiming from './ResourceTiming';
 
 /**
  * @typedef {object} YouTubePlayerInterface
+ * @property {() => number} getAdState
  * @property {() => number} getCurrentTime
  * @property {() => number} getDuration
  * @property {() => string} getPlaybackQuality
@@ -377,8 +378,8 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
     let unplayedBufferSize;
 
     try {
-      const received = Number.parseFloat(this.player.getVideoLoadedFraction());
-      const duration = Number.parseFloat(this.player.getDuration());
+      const received = this.player?.getVideoLoadedFraction();
+      const duration = this.player?.getDuration();
 
       if (Number.isNaN(received) || Number.isNaN(duration)) {
         throw new Error(`NaN`);
@@ -665,8 +666,8 @@ class YouTubeTypeHandler extends GeneralTypeHandler {
 
   get_receive_buffer() {
     try {
-      const received = Number.parseFloat(YouTubeTypeHandler.player?.getVideoLoadedFraction());
-      const duration = Number.parseFloat(YouTubeTypeHandler.player?.getDuration());
+      const received = YouTubeTypeHandler.player?.getVideoLoadedFraction();
+      const duration = YouTubeTypeHandler.player?.getDuration();
 
       if (Number.isNaN(duration) || Number.isNaN(received)) {
         throw new Error('NaN');


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/507

動画プレイヤーのクエリセレクターを変更して、ホーム画面上の動画も計測対象とします。その他若干リファクタリンクも入れました。