### PR TITLE
Svelte コード内の無限ループを修正

### DIFF
--- a/src/lib/pages/history/filters/quality-filter.svelte
+++ b/src/lib/pages/history/filters/quality-filter.svelte
@@ -1,5 +1,6 @@
 <script>
   import { Button, Checkbox, CheckboxGroup, Icon, NumberInput, Slider } from '@sveltia/ui';
+  import { untrack } from 'svelte';
   import { _, locale } from 'svelte-i18n';
   import FilterItem from '$lib/pages/history/filters/filter-item.svelte';
   import { searchCriteria, validQualityStatuses } from '$lib/services/history';
@@ -33,7 +34,14 @@
   };
 
   $effect(() => {
-    onSliderUpdate($searchCriteria.qualityRange);
+    // side effect dependencies
+    // eslint-disable-next-line no-void
+    void [$searchCriteria.qualityRange];
+
+    // Avoid infinite loop
+    untrack(() => {
+      onSliderUpdate();
+    });
   });
 
   $effect(() => {


### PR DESCRIPTION
検索結果ページで Svelte コードが無限ループを起こすようになってしまっているので [`untrack`](https://svelte.dev/docs/svelte/svelte#untrack) を使って解決します。