### PR TITLE
履歴画面で待機時間が表示されない問題を修正

### DIFF
--- a/src/lib/pages/history/detail-panel.svelte
+++ b/src/lib/pages/history/detail-panel.svelte
@@ -101,7 +101,7 @@
           {@const { key, region = {}, startTime, stats } = item}
           {@const { calculable, provisionalQoe, finalQoe, isNewerCodec, isLowQuality } = stats}
           {@const { country, subdivision } = region ?? {}}
-          {@const formattedStats = formatStats($locale, stats)}
+          {@const formattedStats = formatStats($locale, { ...stats, startTime })}
           {@const deleted = $deletedHistoryItemKeys.includes(key)}
           <Group class="view-item">
             <div class="header">


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1217

#275 で履歴の保存先を 2 つの IndexedDB に分割したときに、再生中変化のない `startTime` を統計情報とは別にしたのが原因でした。簡単な変更で、手元で修正を確認したのでマージしてしまいます。