### PR TITLE
YouTube でスループットを取得できていない問題を修正

### DIFF
--- a/src/lib/content/sodium/modules/YouTubeTypeHandler.js
+++ b/src/lib/content/sodium/modules/YouTubeTypeHandler.js
@@ -34,7 +34,7 @@ function isYouTubeVideoResource(url) {
     (['www.youtube.com', 'www.youtube-nocookie.com'].includes(host) &&
       pathname.startsWith('/embed/')) ||
     // 動画のチャンク
-    (host.endsWith('.googlevideo.com') && pathname === 'videoplayback')
+    (host.endsWith('.googlevideo.com') && pathname === '/videoplayback')
   );
 }
 


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1216

#360 からのリグレッションを修正します 😢 

- CSP を削除する `declarativeNetRequest` API がうまく機能せず、既存のルールが無視されているようなので、毎回削除し新たに追加し直すようにしました。正規表現が間違っているのかと疑ったのですが、新規 Chrome プロフィールでは問題ないので、単に API の問題のようです。
- YouTube 動画チャンク URL パスの判定が間違っていました。

ちなみにオーバーレイ上のスループットも表示されていませんが、これは元々ちゃんと表示されていなかったように記憶しているし計測には支障ないので、後回しにします。(どういうチャート表示が正しいのか分かりません 🙃)