### PR TITLE
拡張機能からのデータ送信を中止する

### DIFF
--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -7,6 +7,11 @@ import { videoPlatforms } from '$lib/services/video-platforms';
 export const QOE_ENABLED = false;
 
 /**
+ * Sodium サーバー側でデータ収集を行うかどうかのフラグ。
+ */
+export const DATA_COLLECTION_ENABLED = false;
+
+/**
  * YouTube 動画プレイヤーのクエリセレクター。
  */
 export const YOUTUBE_PLAYER_SELECTOR =

--- a/src/lib/content/sodium/modules/Config.js
+++ b/src/lib/content/sodium/modules/Config.js
@@ -7,9 +7,9 @@ import { videoPlatforms } from '$lib/services/video-platforms';
 export const QOE_ENABLED = false;
 
 /**
- * Sodium サーバー側でデータ収集を行うかどうかのフラグ。
+ * 拡張機能から Sodium サーバーへ計測データ送信を行うかどうかのフラグ。
  */
-export const DATA_COLLECTION_ENABLED = false;
+export const DATA_SUBMISSION_ENABLED = false;
 
 /**
  * YouTube 動画プレイヤーのクエリセレクター。

--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -4,7 +4,7 @@ import { encode } from '@msgpack/msgpack';
 import { v4 as uuidv4 } from 'uuid';
 import { getDataFromContentJs } from '$lib/content/sodium/modules/Utils';
 import { version } from '../../../../../package.json';
-import Config, { QOE_ENABLED } from './Config';
+import Config, { DATA_COLLECTION_ENABLED, QOE_ENABLED } from './Config';
 import MainVideoChangeException from './MainVideoChangeException';
 import ResourceTiming from './ResourceTiming';
 import {
@@ -384,6 +384,10 @@ export default class SessionData {
   }
 
   startDataTransaction(mainVideo, interval) {
+    if (!DATA_COLLECTION_ENABLED) {
+      return null;
+    }
+
     return setTimeout(async () => {
       for (; mainVideo === this.get_main_video(); ) {
         if (mainVideo.is_available()) {

--- a/src/lib/content/sodium/modules/SessionData.js
+++ b/src/lib/content/sodium/modules/SessionData.js
@@ -4,7 +4,7 @@ import { encode } from '@msgpack/msgpack';
 import { v4 as uuidv4 } from 'uuid';
 import { getDataFromContentJs } from '$lib/content/sodium/modules/Utils';
 import { version } from '../../../../../package.json';
-import Config, { DATA_COLLECTION_ENABLED, QOE_ENABLED } from './Config';
+import Config, { DATA_SUBMISSION_ENABLED, QOE_ENABLED } from './Config';
 import MainVideoChangeException from './MainVideoChangeException';
 import ResourceTiming from './ResourceTiming';
 import {
@@ -384,7 +384,7 @@ export default class SessionData {
   }
 
   startDataTransaction(mainVideo, interval) {
-    if (!DATA_COLLECTION_ENABLED) {
+    if (!DATA_SUBMISSION_ENABLED) {
       return null;
     }
 


### PR DESCRIPTION
Fix https://github.com/webdino/sodium/issues/1261

QoE と同様にフラグを立てて、関連コードは残しつつデータ送信を無効化します。